### PR TITLE
Implement VFE Viewer Component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,7 @@ function App() {
 
   const alternative: Photosphere = {
     id: "alternativeSphere",
-    src: outcropWide,
+    src: outcropWide, // TODO: replace with an actual panoramic image that is different from sampleScene
     hotspot: [],
     backgroundAudio: "",
   };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,29 +1,29 @@
+import { Hotspot3D, NavMap, Photosphere, VFE } from "./DataStructures.ts";
 import VFEViewer from "./VFEViewer.tsx";
 import sampleScene from "./assets/VFEdata/ERI_Scene6-IMG_20231006_081813_00_122.jpg";
 import flowers from "./assets/VFEdata/flowers.png";
 import outcropWide from "./assets/VFEdata/outcropWideView.png";
-import { HotSpot3d, NavMap, Photosphere, VFE } from "./dataStructures.ts";
 
 function App() {
-  const hotspotArray: HotSpot3d[] = [
+  const hotspotArray: Hotspot3D[] = [
     {
       pitch: 5,
       yaw: -5,
-      toolTip: "Outcrop wideview",
+      tooltip: "Outcrop wideview",
       data: {
         tag: "Image",
         src: outcropWide,
-        hotspot: [],
+        hotspots: [],
       },
     },
     {
       pitch: -3,
       yaw: 18,
-      toolTip: "Flowers",
+      tooltip: "Flowers",
       data: {
         tag: "Image",
         src: flowers,
-        hotspot: [],
+        hotspots: [],
       },
     },
   ];
@@ -31,26 +31,26 @@ function App() {
   const prototype: Photosphere = {
     id: "prototypeSphere",
     src: sampleScene,
-    hotspot: hotspotArray,
+    hotspots: hotspotArray,
     backgroundAudio: "",
   };
 
   const alternative: Photosphere = {
     id: "alternativeSphere",
     src: outcropWide, // TODO: replace with an actual panoramic image that is different from sampleScene
-    hotspot: [],
+    hotspots: [],
     backgroundAudio: "",
   };
 
   const map: NavMap = {
     src: "map src",
-    hotspot: [],
+    hotspots: [],
   };
 
   const data: VFE = {
     name: "prototypeElkIslandVFE",
     map: map,
-    photospere: [prototype, alternative],
+    photospheres: [prototype, alternative],
   };
 
   return <VFEViewer vfe={data} />;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import PhotoSphereViewer from "./PhotoSphereViewer.tsx";
+import VFEViewer from "./VFEViewer.tsx";
 import sampleScene from "./assets/VFEdata/ERI_Scene6-IMG_20231006_081813_00_122.jpg";
 import flowers from "./assets/VFEdata/flowers.png";
 import outcropWide from "./assets/VFEdata/outcropWideView.png";
@@ -35,6 +35,13 @@ function App() {
     backgroundAudio: "",
   };
 
+  const alternative: Photosphere = {
+    id: "alternativeSphere",
+    src: outcropWide,
+    hotspot: [],
+    backgroundAudio: "",
+  };
+
   const map: NavMap = {
     src: "map src",
     hotspot: [],
@@ -43,10 +50,10 @@ function App() {
   const data: VFE = {
     name: "prototypeElkIslandVFE",
     map: map,
-    photospere: [prototype],
+    photospere: [prototype, alternative],
   };
 
-  return <PhotoSphereViewer {...data} />;
+  return <VFEViewer vfe={data} />;
 }
 
 export default App;

--- a/src/DataStructures.ts
+++ b/src/DataStructures.ts
@@ -1,9 +1,9 @@
 /* -----------------------------------------------------------------------
                     Virtual Field Environment Software
    -----------------------------------------------------------------------
-    Instantiation of the objects that will be used for interacting with 
-    Photo Sphere Viewer to build a virtual geology field guide. 
-    Order listed from big-picture environment collection 
+    Instantiation of the objects that will be used for interacting with
+    Photo Sphere Viewer to build a virtual geology field guide.
+    Order listed from big-picture environment collection
     to micro-environments and associated elements.
    ----------------------------------------------------------------------- */
 
@@ -11,47 +11,47 @@
 export interface VFE {
   name: string;
   map: NavMap;
-  photospere: Photosphere[];
+  photospheres: Photosphere[];
 }
 
 // Navigation map: a birdseye view of the various hotspots within a single 360-environment
 export interface NavMap {
   src: string;
-  hotspot: HotSpot3d[];
+  hotspots: Hotspot2D[];
 }
 
 // Photosphere: a single 360-environment
 export interface Photosphere {
   id: string;
   src: string;
-  hotspot: HotSpot3d[];
+  hotspots: Hotspot3D[];
   backgroundAudio: string;
 }
 
-// hotspot: a clickable resource that is 2d (x, y)
-export interface HotSpot2d {
+// Hotspot2D: a clickable resource that is inside a 2D image (x, y)
+export interface Hotspot2D {
   x: number;
   y: number;
-  toolTip: string;
-  data: HotSpotData;
+  tooltip: string;
+  data: HotspotData;
 }
 
-// hotspot: a clickable resource that is a 360 image (pitch, yaw)
-export interface HotSpot3d {
+// Hotspot3D: a clickable resource that is inside a 360 photosphere (pitch, yaw)
+export interface Hotspot3D {
   pitch: number;
   yaw: number;
-  toolTip: string;
-  data: HotSpotData;
+  tooltip: string;
+  data: HotspotData;
 }
 
-// hotSpotData: types of media resources for a hotspot within a photosphere
-export type HotSpotData = Image | Audio | Video | URL | Doc | PhotosphereLink;
+// HotspotData: types of media resources for a hotspot within a photosphere
+export type HotspotData = Image | Audio | Video | URL | Doc | PhotosphereLink;
 
 // media objects
 export interface Image {
   tag: "Image";
   src: string;
-  hotspot: HotSpot2d[];
+  hotspots: Hotspot2D[];
 }
 
 export interface Video {
@@ -76,5 +76,5 @@ export interface Doc {
 
 export interface PhotosphereLink {
   tag: "PhotosphereLink";
-  photosphereId: string;
+  photosphereID: string;
 }

--- a/src/PhotoSphereSelector.tsx
+++ b/src/PhotoSphereSelector.tsx
@@ -1,0 +1,44 @@
+export interface PhotoSphereSelectorProps {
+  options: string[];
+  value: string | undefined;
+  setValue: (value: string | undefined) => void;
+}
+
+function PhotoSphereSelector(props: PhotoSphereSelectorProps) {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        top: "16px",
+        left: 0,
+        right: 0,
+        width: "200px",
+        padding: "4px",
+        marginLeft: "auto",
+        marginRight: "auto",
+        backgroundColor: "white",
+        borderRadius: "4px",
+        boxShadow: "0 0 4px grey",
+        zIndex: 100,
+      }}
+    >
+      <label htmlFor="scene-select">Scene: </label>
+      <select
+        id="scene-select"
+        value={props.value}
+        onChange={(e) => {
+          props.setValue(e.target.value);
+        }}
+        style={{ paddingInline: "8px", paddingBlock: "4px", width: "150px" }}
+      >
+        {props.options.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+export default PhotoSphereSelector;

--- a/src/PhotoSphereViewer.tsx
+++ b/src/PhotoSphereViewer.tsx
@@ -1,9 +1,12 @@
 import { ViewerConfig } from "@photo-sphere-viewer/core";
-import { useEffect, useState } from "react";
+import { MarkerConfig } from "@photo-sphere-viewer/markers-plugin";
+import React, { useEffect, useState } from "react";
 import {
   MapPlugin,
+  MapPluginConfig,
   MarkersPlugin,
   ReactPhotoSphereViewer,
+  ViewerAPI,
 } from "react-photo-sphere-viewer";
 
 import Contact from "./assets/VFEdata/Contact.png";
@@ -23,7 +26,7 @@ import paddlers from "./assets/VFEdata/paddlers.mp4";
 import shorelineSOUTH from "./assets/VFEdata/shorelineSOUTH.mp4";
 import smallPool from "./assets/VFEdata/small_pool.jpg";
 import SEMComp from "./assets/VFEdata/southSEMcomp.png";
-import { NavMap, Photosphere } from "./dataStructures";
+import { HotSpot3d, NavMap, Photosphere } from "./dataStructures";
 
 function videoContent(src: string): string {
   return `<video controls style="max-width: 100%; max-height: 100%">
@@ -37,6 +40,185 @@ function pictureContent(imageSrc: string) {
     `;
 }
 
+const baseUrl = "https://photo-sphere-viewer-data.netlify.app/assets/";
+
+function convertHotspots(hotspots: HotSpot3d[]): MarkerConfig[] {
+  if (hotspots.length == 0) return [];
+
+  // TODO: conversion from hotspots instead of hardcoding
+  return [
+    {
+      id: "outcropWideView",
+      image: baseUrl + "pictos/pin-blue.png",
+      size: { width: 64, height: 64 },
+      position: { yaw: "-5deg", pitch: "5deg" },
+      tooltip: "Outcrop wideview",
+      content: pictureContent(outcropWide),
+    },
+    {
+      id: "flowers",
+      image: baseUrl + "pictos/pin-blue.png",
+      size: { width: 64, height: 64 },
+      position: { yaw: "18deg", pitch: "-3deg" },
+      tooltip: "Flowers",
+      content: pictureContent(flowers),
+    },
+    {
+      id: "shorelineSOUTH",
+      image: baseUrl + "pictos/pin-red.png",
+      size: { width: 64, height: 64 },
+      position: { yaw: "172deg", pitch: "-32deg" },
+      tooltip: "shorelineSOUTH.mp4",
+      content: videoContent(shorelineSOUTH),
+    },
+    {
+      id: "paddlers",
+      image: baseUrl + "pictos/pin-red.png",
+      size: { width: 64, height: 64 },
+      position: { yaw: "-175deg", pitch: "-10deg" },
+      tooltip: "paddlers.mp4",
+      content: videoContent(paddlers),
+    },
+    {
+      id: "small pool",
+      image: baseUrl + "pictos/pin-blue.png",
+      size: { width: 64, height: 64 },
+      position: { yaw: "100deg", pitch: "-13deg" },
+      content: pictureContent(smallPool),
+      tooltip: "small pool",
+    },
+    {
+      id: "log near shoreline",
+      image: baseUrl + "pictos/pin-blue.png",
+      size: { width: 64, height: 64 },
+      position: { yaw: "-40deg", pitch: "-25deg" },
+      content: pictureContent(logNEARshorline),
+      tooltip: "log near shoreline",
+    },
+    {
+      id: "coolLog",
+      image: baseUrl + "pictos/pin-blue.png",
+      size: { width: 64, height: 64 },
+      position: { yaw: "-33deg", pitch: "-17deg" },
+      content: pictureContent(coolLog),
+      tooltip: "a cool log",
+    },
+    {
+      id: "handSample",
+      image: baseUrl + "pictos/pin-blue.png",
+      size: { width: 64, height: 64 },
+      position: { yaw: "-44deg", pitch: "0deg" },
+      content: pictureContent(handSample),
+      tooltip: "hand sample of stone",
+    },
+    {
+      id: "outcropTextures",
+      image: baseUrl + "pictos/pin-red.png",
+      size: { width: 64, height: 64 },
+      position: { yaw: "5deg", pitch: "6deg" },
+      content: videoContent(outcropTextures),
+      tooltip: "outcrop textures video",
+    },
+    {
+      id: "logs",
+      image: baseUrl + "pictos/pin-blue.png",
+      size: { width: 64, height: 64 },
+      position: { yaw: "-37deg", pitch: "-12deg" },
+      tooltip: "How did these huge logs get here?",
+    },
+    {
+      id: "mushroom",
+      image: baseUrl + "pictos/pin-blue.png",
+      size: { width: 64, height: 64 },
+      position: { yaw: "-19deg", pitch: "2deg" },
+      content: pictureContent(mushroom),
+      tooltip: "mushroom",
+    },
+    {
+      id: "closerLook",
+      image: baseUrl + "pictos/pin-blue.png",
+      size: { width: 64, height: 64 },
+      position: { yaw: "-46deg", pitch: "-2deg" },
+      content: pictureContent(closerLook),
+      tooltip: "A closer look",
+    },
+    {
+      id: "SEMComp",
+      image: baseUrl + "pictos/pin-blue.png",
+      size: { width: 64, height: 64 },
+      position: { yaw: "-48deg", pitch: "0deg" },
+      content: pictureContent(SEMComp),
+      tooltip: "South SEM Comparisson",
+    },
+    {
+      id: "Contact",
+      image: baseUrl + "pictos/pin-blue.png",
+      size: { width: 64, height: 64 },
+      position: { yaw: "-46deg", pitch: "2deg" },
+      content: pictureContent(Contact),
+      tooltip: "Contact",
+    },
+    {
+      id: "South Waterfront",
+      image: baseUrl + "pictos/pin-blue.png",
+      size: { width: 64, height: 64 },
+      position: { yaw: "-25deg", pitch: "-1deg" },
+      content: pictureContent(SouthwaterFront),
+      tooltip: "South Waterfront",
+    },
+  ];
+}
+
+function convertMap(map: NavMap): MapPluginConfig {
+  // this line is so the map variable does not cause unused variable errors
+  // TODO: remove this line after conversion functionality is completed
+  void map;
+
+  // TODO: conversion from NavMap instead of hardcoding
+  return {
+    imageUrl: mapImage,
+    center: { x: 450, y: 800 },
+    rotation: "0deg",
+    defaultZoom: 20,
+    hotspots: [
+      {
+        x: 95,
+        y: 530,
+        id: "West",
+        color: "yellow",
+        tooltip: "West",
+      },
+      {
+        x: 450,
+        y: 800,
+        id: "South",
+        color: "yellow",
+        tooltip: "South",
+      },
+      {
+        x: 650,
+        y: 930,
+        id: "Entrance",
+        color: "yellow",
+        tooltip: "Entrance",
+      },
+      {
+        x: 550,
+        y: 450,
+        id: "East",
+        color: "yellow",
+        tooltip: "East",
+      },
+      {
+        x: 390,
+        y: 50,
+        id: "North",
+        color: "yellow",
+        tooltip: "North",
+      },
+    ],
+  };
+}
 export interface PhotoSphereViewerProps {
   photosphere: Photosphere;
   map: NavMap;
@@ -44,6 +226,31 @@ export interface PhotoSphereViewerProps {
 
 function PhotoSphereViewer(props: PhotoSphereViewerProps) {
   const [isUserInteracted, setIsUserInteracted] = useState(false);
+  const photoSphereRef = React.createRef<ViewerAPI>();
+
+  // handle change of panoramic image
+  useEffect(() => {
+    void photoSphereRef.current?.setPanorama(props.photosphere.src);
+  }, [props.photosphere.src, photoSphereRef]);
+
+  // handle change of hotspots
+  useEffect(() => {
+    const markers: MarkersPlugin | undefined =
+      photoSphereRef.current?.getPlugin(MarkersPlugin);
+    markers?.setMarkers(convertHotspots(props.photosphere.hotspot));
+  }, [props.photosphere.hotspot, photoSphereRef]);
+
+  // handle change of map
+  useEffect(() => {
+    const map: MapPlugin | undefined =
+      photoSphereRef.current?.getPlugin(MapPlugin);
+
+    const newOptions = convertMap(props.map);
+    if (newOptions.imageUrl) map?.setImage(newOptions.imageUrl);
+    if (newOptions.center) map?.setCenter(newOptions.center);
+    if (newOptions.hotspots) map?.setHotspots(newOptions.hotspots);
+    map?.setOption("rotation", newOptions.rotation);
+  }, [props.map, photoSphereRef]);
 
   useEffect(() => {
     const audio = new Audio(audioFile);
@@ -91,180 +298,9 @@ function PhotoSphereViewer(props: PhotoSphereViewerProps) {
     );
   }
 
-  const baseUrl = "https://photo-sphere-viewer-data.netlify.app/assets/";
   const plugins: ViewerConfig["plugins"] = [
-    [
-      MarkersPlugin,
-      {
-        markers: [
-          {
-            id: "outcropWideView",
-            image: baseUrl + "pictos/pin-blue.png",
-            size: { width: 64, height: 64 },
-            position: { yaw: "-5deg", pitch: "5deg" },
-            tooltip: "Outcrop wideview",
-            content: pictureContent(outcropWide),
-          },
-          {
-            id: "flowers",
-            image: baseUrl + "pictos/pin-blue.png",
-            size: { width: 64, height: 64 },
-            position: { yaw: "18deg", pitch: "-3deg" },
-            tooltip: "Flowers",
-            content: pictureContent(flowers),
-          },
-          {
-            id: "shorelineSOUTH",
-            image: baseUrl + "pictos/pin-red.png",
-            size: { width: 64, height: 64 },
-            position: { yaw: "172deg", pitch: "-32deg" },
-            tooltip: "shorelineSOUTH.mp4",
-            content: videoContent(shorelineSOUTH),
-          },
-          {
-            id: "paddlers",
-            image: baseUrl + "pictos/pin-red.png",
-            size: { width: 64, height: 64 },
-            position: { yaw: "-175deg", pitch: "-10deg" },
-            tooltip: "paddlers.mp4",
-            content: videoContent(paddlers),
-          },
-          {
-            id: "small pool",
-            image: baseUrl + "pictos/pin-blue.png",
-            size: { width: 64, height: 64 },
-            position: { yaw: "100deg", pitch: "-13deg" },
-            content: pictureContent(smallPool),
-            tooltip: "small pool",
-          },
-          {
-            id: "log near shoreline",
-            image: baseUrl + "pictos/pin-blue.png",
-            size: { width: 64, height: 64 },
-            position: { yaw: "-40deg", pitch: "-25deg" },
-            content: pictureContent(logNEARshorline),
-            tooltip: "log near shoreline",
-          },
-          {
-            id: "coolLog",
-            image: baseUrl + "pictos/pin-blue.png",
-            size: { width: 64, height: 64 },
-            position: { yaw: "-33deg", pitch: "-17deg" },
-            content: pictureContent(coolLog),
-            tooltip: "a cool log",
-          },
-          {
-            id: "handSample",
-            image: baseUrl + "pictos/pin-blue.png",
-            size: { width: 64, height: 64 },
-            position: { yaw: "-44deg", pitch: "0deg" },
-            content: pictureContent(handSample),
-            tooltip: "hand sample of stone",
-          },
-          {
-            id: "outcropTextures",
-            image: baseUrl + "pictos/pin-red.png",
-            size: { width: 64, height: 64 },
-            position: { yaw: "5deg", pitch: "6deg" },
-            content: videoContent(outcropTextures),
-            tooltip: "outcrop textures video",
-          },
-          {
-            id: "logs",
-            image: baseUrl + "pictos/pin-blue.png",
-            size: { width: 64, height: 64 },
-            position: { yaw: "-37deg", pitch: "-12deg" },
-            tooltip: "How did these huge logs get here?",
-          },
-          {
-            id: "mushroom",
-            image: baseUrl + "pictos/pin-blue.png",
-            size: { width: 64, height: 64 },
-            position: { yaw: "-19deg", pitch: "2deg" },
-            content: pictureContent(mushroom),
-            tooltip: "mushroom",
-          },
-          {
-            id: "closerLook",
-            image: baseUrl + "pictos/pin-blue.png",
-            size: { width: 64, height: 64 },
-            position: { yaw: "-46deg", pitch: "-2deg" },
-            content: pictureContent(closerLook),
-            tooltip: "A closer look",
-          },
-          {
-            id: "SEMComp",
-            image: baseUrl + "pictos/pin-blue.png",
-            size: { width: 64, height: 64 },
-            position: { yaw: "-48deg", pitch: "0deg" },
-            content: pictureContent(SEMComp),
-            tooltip: "South SEM Comparisson",
-          },
-          {
-            id: "Contact",
-            image: baseUrl + "pictos/pin-blue.png",
-            size: { width: 64, height: 64 },
-            position: { yaw: "-46deg", pitch: "2deg" },
-            content: pictureContent(Contact),
-            tooltip: "Contact",
-          },
-          {
-            id: "South Waterfront",
-            image: baseUrl + "pictos/pin-blue.png",
-            size: { width: 64, height: 64 },
-            position: { yaw: "-25deg", pitch: "-1deg" },
-            content: pictureContent(SouthwaterFront),
-            tooltip: "South Waterfront",
-          },
-        ],
-      },
-    ],
-    [
-      MapPlugin,
-      {
-        imageUrl: mapImage,
-        center: { x: 450, y: 800 },
-        rotation: "0deg",
-        defaultZoom: 20,
-        hotspots: [
-          {
-            x: 95,
-            y: 530,
-            id: "West",
-            color: "yellow",
-            tooltip: "West",
-          },
-          {
-            x: 450,
-            y: 800,
-            id: "South",
-            color: "yellow",
-            tooltip: "South",
-          },
-          {
-            x: 650,
-            y: 930,
-            id: "Entrance",
-            color: "yellow",
-            tooltip: "Entrance",
-          },
-          {
-            x: 550,
-            y: 450,
-            id: "East",
-            color: "yellow",
-            tooltip: "East",
-          },
-          {
-            x: 390,
-            y: 50,
-            id: "North",
-            color: "yellow",
-            tooltip: "North",
-          },
-        ],
-      },
-    ],
+    [MarkersPlugin, { markers: convertHotspots(props.photosphere.hotspot) }],
+    [MapPlugin, convertMap(props.map)],
   ];
 
   console.log({ plugins });
@@ -273,6 +309,7 @@ function PhotoSphereViewer(props: PhotoSphereViewerProps) {
 
   return (
     <ReactPhotoSphereViewer
+      ref={photoSphereRef}
       src={sampleScene}
       plugins={plugins}
       height={"100vh"}

--- a/src/PhotoSphereViewer.tsx
+++ b/src/PhotoSphereViewer.tsx
@@ -23,7 +23,7 @@ import paddlers from "./assets/VFEdata/paddlers.mp4";
 import shorelineSOUTH from "./assets/VFEdata/shorelineSOUTH.mp4";
 import smallPool from "./assets/VFEdata/small_pool.jpg";
 import SEMComp from "./assets/VFEdata/southSEMcomp.png";
-import { VFE } from "./dataStructures";
+import { NavMap, Photosphere } from "./dataStructures";
 
 function videoContent(src: string): string {
   return `<video controls style="max-width: 100%; max-height: 100%">
@@ -37,7 +37,12 @@ function pictureContent(imageSrc: string) {
     `;
 }
 
-function PhotoSphereViewer(data: VFE) {
+export interface PhotoSphereViewerProps {
+  photosphere: Photosphere;
+  map: NavMap;
+}
+
+function PhotoSphereViewer(props: PhotoSphereViewerProps) {
   const [isUserInteracted, setIsUserInteracted] = useState(false);
 
   useEffect(() => {
@@ -263,8 +268,8 @@ function PhotoSphereViewer(data: VFE) {
   ];
 
   console.log({ plugins });
-  console.log(data);
-  console.log(data.name);
+  console.log(props.photosphere);
+  console.log(props.map);
 
   return (
     <ReactPhotoSphereViewer
@@ -272,7 +277,7 @@ function PhotoSphereViewer(data: VFE) {
       plugins={plugins}
       height={"100vh"}
       width={"100%"}
-    ></ReactPhotoSphereViewer>
+    />
   );
 }
 

--- a/src/PhotosphereSelector.tsx
+++ b/src/PhotosphereSelector.tsx
@@ -1,10 +1,10 @@
-export interface PhotoSphereSelectorProps {
+export interface PhotosphereSelectorProps {
   options: string[];
   value: string | undefined;
   setValue: (value: string | undefined) => void;
 }
 
-function PhotoSphereSelector(props: PhotoSphereSelectorProps) {
+function PhotosphereSelector(props: PhotosphereSelectorProps) {
   return (
     <div
       style={{
@@ -41,4 +41,4 @@ function PhotoSphereSelector(props: PhotoSphereSelectorProps) {
   );
 }
 
-export default PhotoSphereSelector;
+export default PhotosphereSelector;

--- a/src/PhotosphereViewer.tsx
+++ b/src/PhotosphereViewer.tsx
@@ -9,6 +9,7 @@ import {
   ViewerAPI,
 } from "react-photo-sphere-viewer";
 
+import { Hotspot3D, NavMap, Photosphere } from "./DataStructures";
 import Contact from "./assets/VFEdata/Contact.png";
 import sampleScene from "./assets/VFEdata/ERI_Scene6-IMG_20231006_081813_00_122.jpg";
 import audioFile from "./assets/VFEdata/Scene12_UnevenStandTop_LS100146.mp3";
@@ -26,7 +27,6 @@ import paddlers from "./assets/VFEdata/paddlers.mp4";
 import shorelineSOUTH from "./assets/VFEdata/shorelineSOUTH.mp4";
 import smallPool from "./assets/VFEdata/small_pool.jpg";
 import SEMComp from "./assets/VFEdata/southSEMcomp.png";
-import { HotSpot3d, NavMap, Photosphere } from "./dataStructures";
 
 function videoContent(src: string): string {
   return `<video controls style="max-width: 100%; max-height: 100%">
@@ -42,7 +42,7 @@ function pictureContent(imageSrc: string) {
 
 const baseUrl = "https://photo-sphere-viewer-data.netlify.app/assets/";
 
-function convertHotspots(hotspots: HotSpot3d[]): MarkerConfig[] {
+function convertHotspots(hotspots: Hotspot3D[]): MarkerConfig[] {
   if (hotspots.length == 0) return [];
 
   // TODO: conversion from hotspots instead of hardcoding
@@ -148,7 +148,7 @@ function convertHotspots(hotspots: HotSpot3d[]): MarkerConfig[] {
       size: { width: 64, height: 64 },
       position: { yaw: "-48deg", pitch: "0deg" },
       content: pictureContent(SEMComp),
-      tooltip: "South SEM Comparisson",
+      tooltip: "South SEM Comparison",
     },
     {
       id: "Contact",
@@ -219,12 +219,12 @@ function convertMap(map: NavMap): MapPluginConfig {
     ],
   };
 }
-export interface PhotoSphereViewerProps {
+export interface PhotosphereViewerProps {
   photosphere: Photosphere;
   map: NavMap;
 }
 
-function PhotoSphereViewer(props: PhotoSphereViewerProps) {
+function PhotosphereViewer(props: PhotosphereViewerProps) {
   const [isUserInteracted, setIsUserInteracted] = useState(false);
   const photoSphereRef = React.createRef<ViewerAPI>();
 
@@ -237,8 +237,8 @@ function PhotoSphereViewer(props: PhotoSphereViewerProps) {
   useEffect(() => {
     const markers: MarkersPlugin | undefined =
       photoSphereRef.current?.getPlugin(MarkersPlugin);
-    markers?.setMarkers(convertHotspots(props.photosphere.hotspot));
-  }, [props.photosphere.hotspot, photoSphereRef]);
+    markers?.setMarkers(convertHotspots(props.photosphere.hotspots));
+  }, [props.photosphere.hotspots, photoSphereRef]);
 
   // handle change of map
   useEffect(() => {
@@ -292,14 +292,14 @@ function PhotoSphereViewer(props: PhotoSphereViewerProps) {
           onClick={handleUserInteraction}
           style={{ padding: "10px 20px", fontSize: "16px" }}
         >
-          Start Virtual Enviornment
+          Start Virtual Environment
         </button>
       </div>
     );
   }
 
   const plugins: ViewerConfig["plugins"] = [
-    [MarkersPlugin, { markers: convertHotspots(props.photosphere.hotspot) }],
+    [MarkersPlugin, { markers: convertHotspots(props.photosphere.hotspots) }],
     [MapPlugin, convertMap(props.map)],
   ];
 
@@ -318,4 +318,4 @@ function PhotoSphereViewer(props: PhotoSphereViewerProps) {
   );
 }
 
-export default PhotoSphereViewer;
+export default PhotosphereViewer;

--- a/src/VFEViewer.tsx
+++ b/src/VFEViewer.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+
+import PhotoSphereViewer from "./PhotoSphereViewer";
+import PhotoSphereSelector from "./PhotosphereSelector";
+import { Photosphere, VFE } from "./dataStructures";
+
+export interface VFEViewerProps {
+  vfe: VFE;
+}
+
+function VFEViewer({ vfe }: VFEViewerProps) {
+  const photoSphereMap: Record<string, Photosphere> = Object.fromEntries(
+    vfe.photospere.map((p) => [p.id, p]),
+  );
+
+  const [currentPhotoSphereID, setCurrentPhotoSphereID] = useState<
+    string | undefined
+  >(vfe.photospere[0]?.id);
+
+  return (
+    <>
+      <PhotoSphereSelector
+        options={vfe.photospere.map((p) => p.id)}
+        value={currentPhotoSphereID}
+        setValue={setCurrentPhotoSphereID}
+      />
+      {currentPhotoSphereID !== undefined ? (
+        <PhotoSphereViewer
+          photosphere={photoSphereMap[currentPhotoSphereID]}
+          map={vfe.map}
+        />
+      ) : (
+        <div
+          style={{
+            height: "100vh",
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+          }}
+        >
+          No photosphere selected
+        </div>
+      )}
+    </>
+  );
+}
+
+export default VFEViewer;

--- a/src/VFEViewer.tsx
+++ b/src/VFEViewer.tsx
@@ -1,32 +1,32 @@
 import { useState } from "react";
 
-import PhotoSphereViewer from "./PhotoSphereViewer";
-import PhotoSphereSelector from "./PhotosphereSelector";
-import { Photosphere, VFE } from "./dataStructures";
+import { Photosphere, VFE } from "./DataStructures";
+import PhotosphereSelector from "./PhotosphereSelector";
+import PhotosphereViewer from "./PhotosphereViewer";
 
 export interface VFEViewerProps {
   vfe: VFE;
 }
 
 function VFEViewer({ vfe }: VFEViewerProps) {
-  const photoSphereMap: Record<string, Photosphere> = Object.fromEntries(
-    vfe.photospere.map((p) => [p.id, p]),
+  const photosphereMap: Record<string, Photosphere> = Object.fromEntries(
+    vfe.photospheres.map((p) => [p.id, p]),
   );
 
-  const [currentPhotoSphereID, setCurrentPhotoSphereID] = useState<
+  const [currentPhotosphereID, setCurrentPhotosphereID] = useState<
     string | undefined
-  >(vfe.photospere[0]?.id);
+  >(vfe.photospheres[0]?.id);
 
   return (
     <>
-      <PhotoSphereSelector
-        options={vfe.photospere.map((p) => p.id)}
-        value={currentPhotoSphereID}
-        setValue={setCurrentPhotoSphereID}
+      <PhotosphereSelector
+        options={vfe.photospheres.map((p) => p.id)}
+        value={currentPhotosphereID}
+        setValue={setCurrentPhotosphereID}
       />
-      {currentPhotoSphereID !== undefined ? (
-        <PhotoSphereViewer
-          photosphere={photoSphereMap[currentPhotoSphereID]}
+      {currentPhotosphereID !== undefined ? (
+        <PhotosphereViewer
+          photosphere={photosphereMap[currentPhotosphereID]}
           map={vfe.map}
         />
       ) : (


### PR DESCRIPTION
Closes #23

This PR adds the VFEViewer component that holds the state for the currently selected photosphere and includes a `<select>` dropdown to switch between photospheres. I added the `alternative` photosphere as a demonstration; it just uses a random non-360 image as the `src` so the difference is visible. We might want to use the [VirtualTourPlugin](https://photo-sphere-viewer.js.org/plugins/virtual-tour.html) to handle multiple photospheres in the future.

As I was working on the stateful VFEViewer, I noticed the `ReactPhotoSphereViewer` doesn't automatically update when its props change. For that reason, I had to add the two `useEffect` hooks to handle changing data properly. I also extracted the hardcoded objects into functions with `TODO` comments that can be implemented in future PRs.

Finally, this PR also includes a commit to normalize file/variable names for consistency and fix typos. The following changes are included:
- `Hotspot` instead of `HotSpot`.
- `hotspots` instead of `hotspot` for array fields.
- `tooltip` instead of `toolTip`.
- `photosphere` instead of `photoSphere`.