### PR TITLE
Add hotspot button

### DIFF
--- a/src/AddHotspot.tsx
+++ b/src/AddHotspot.tsx
@@ -1,12 +1,75 @@
 import React, { useState } from "react";
 
-import { Hotspot3D, HotspotData, VFE } from "./DataStructures.ts";
+import { Hotspot3D, HotspotData } from "./DataStructures.ts";
 
-interface AddHotspotProps {
-  vfe: VFE;
+interface ContentInputProps {
+  contentType: string;
+  onChangeContent: (content: string) => void;
 }
 
-function AddHotspot({ vfe }: AddHotspotProps) {
+function ContentInput({ contentType, onChangeContent }: ContentInputProps) {
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const URL = reader.result as string;
+        onChangeContent(URL);
+      };
+      reader.readAsDataURL(file);
+    }
+  }
+
+  let label;
+  let input;
+  switch (contentType) {
+    case "Image":
+    case "Video":
+    case "Audio":
+      label = <label htmlFor="content">Content: </label>;
+      input = <input type="file" id="content" onChange={handleFileChange} />;
+      break;
+    case "Doc":
+    case "URL":
+      label = <label htmlFor="content">Content: </label>;
+      input = (
+        <input
+          type="string"
+          id="content"
+          onChange={(e) => onChangeContent(e.target.value)}
+        />
+      );
+      break;
+    case "PhotosphereLink":
+      label = <label htmlFor="content">Photosphere Name: </label>;
+      input = (
+        <input
+          type="string"
+          id="content"
+          onChange={(e) => onChangeContent(e.target.value)}
+        />
+      );
+      break;
+    default:
+      label = <label htmlFor="content"></label>;
+      input = (
+        <span id="content">First select a content type to add content</span>
+      );
+  }
+
+  return (
+    <>
+      {label}
+      {input}
+    </>
+  );
+}
+interface AddHotspotProps {
+  onAddHotspot: (newHotspot: Hotspot3D) => void;
+  onCancel: () => void;
+}
+
+function AddHotspot({ onAddHotspot, onCancel }: AddHotspotProps) {
   // Placeholder content or logic can be added here later
   const [tooltip, setTooltip] = useState("");
   const [contentType, setContentType] = useState("invalid");
@@ -14,22 +77,10 @@ function AddHotspot({ vfe }: AddHotspotProps) {
   const [pitch, setPitch] = useState(0);
   const [yaw, setYaw] = useState(0);
 
-  function handleContentChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = () => {
-        const URL = reader.result as string;
-        setContent(URL);
-      };
-      reader.readAsDataURL(file);
-    }
-  }
-
-  function handleSelectPosition() {
+  /*function handleSelectPosition() {
     // todo
     // get pitch/yaw off of click on viewer
-  }
+  }*/
 
   function handleAddHotspot() {
     if (tooltip.trim() == "" || contentType == "invalid") {
@@ -43,7 +94,7 @@ function AddHotspot({ vfe }: AddHotspotProps) {
         data = {
           tag: "Image",
           src: content,
-          hotspots: [],
+          hotspots: {},
         };
         break;
       case "Video":
@@ -73,7 +124,7 @@ function AddHotspot({ vfe }: AddHotspotProps) {
       case "PhotosphereLink":
         data = {
           tag: "PhotosphereLink",
-          photosphereID: tooltip,
+          photosphereID: content,
         };
         break;
       // should never actually get here
@@ -89,8 +140,7 @@ function AddHotspot({ vfe }: AddHotspotProps) {
       data: data,
     };
 
-    // todo
-    // need a way to know which photosphere is current so can add hotspots in correct spot
+    onAddHotspot(newHotspot);
   }
 
   return (
@@ -138,8 +188,7 @@ function AddHotspot({ vfe }: AddHotspotProps) {
         </select>
       </div>
       <div>
-        <label htmlFor="content">Content: </label>
-        <input type="file" id="content" onChange={handleContentChange} />
+        <ContentInput contentType={contentType} onChangeContent={setContent} />
       </div>
       <div>
         {/*<span>Pitch: </span>
@@ -169,7 +218,14 @@ function AddHotspot({ vfe }: AddHotspotProps) {
           }}
         />
       </div>
-      <button onClick={handleAddHotspot}>Create</button>
+      <div style={{ display: "flex", justifyContent: "space-around" }}>
+        <button style={{ width: "40%" }} onClick={handleAddHotspot}>
+          Create
+        </button>
+        <button style={{ width: "40%" }} onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/AddHotspot.tsx
+++ b/src/AddHotspot.tsx
@@ -71,24 +71,18 @@ function ContentInput({ contentType, onChangeContent }: ContentInputProps) {
 interface AddHotspotProps {
   onAddHotspot: (newHotspot: Hotspot3D) => void;
   onCancel: () => void;
+  pitch: number;
+  yaw: number;
 }
 
-function AddHotspot({ onAddHotspot, onCancel }: AddHotspotProps) {
-  // Placeholder content or logic can be added here later
+function AddHotspot({ onAddHotspot, onCancel, pitch, yaw }: AddHotspotProps) {
   const [tooltip, setTooltip] = useState("");
   const [contentType, setContentType] = useState("invalid");
   const [content, setContent] = useState("");
-  const [pitch, setPitch] = useState(0);
-  const [yaw, setYaw] = useState(0);
-
-  /*function handleSelectPosition() {
-    // todo
-    // get pitch/yaw off of click on viewer
-  }*/
 
   function handleAddHotspot() {
     if (tooltip.trim() == "" || contentType == "invalid") {
-      alert("Please provide a tooltip, a valid content type, and location");
+      alert("Please provide a tooltip and a valid content type");
       return;
     }
 
@@ -195,32 +189,12 @@ function AddHotspot({ onAddHotspot, onCancel }: AddHotspotProps) {
         <ContentInput contentType={contentType} onChangeContent={setContent} />
       </div>
       <div>
-        {/*<span>Pitch: </span>
-        <span id="pitch">{String(pitch)}</span>
+        <span>Pitch: </span>
+        <span id="pitch">{String(pitch.toFixed(2))}</span>
         <span>Yaw: </span>
-        <span id="yaw">{String(yaw)}</span>
+        <span id="yaw">{String(yaw.toFixed(2))}</span>
         <br />
-        <button onClick={handleSelectPosition}>Select Position</button>*/}
-        <label htmlFor="pitch">Pitch: </label>
-        <input
-          style={{ width: 30 }}
-          type="string"
-          id="pitch"
-          value={pitch}
-          onChange={(e) => {
-            setPitch(parseInt(e.target.value));
-          }}
-        />
-        <label htmlFor="yaw">Yaw: </label>
-        <input
-          style={{ width: 30 }}
-          type="string"
-          id="yaw"
-          value={yaw}
-          onChange={(e) => {
-            setYaw(parseInt(e.target.value));
-          }}
-        />
+        <span>Click on viewer for pitch and yaw</span>
       </div>
       <div style={{ display: "flex", justifyContent: "space-around" }}>
         <button style={{ width: "40%" }} onClick={handleAddHotspot}>

--- a/src/AddHotspot.tsx
+++ b/src/AddHotspot.tsx
@@ -36,7 +36,9 @@ function ContentInput({ contentType, onChangeContent }: ContentInputProps) {
         <input
           type="string"
           id="content"
-          onChange={(e) => onChangeContent(e.target.value)}
+          onChange={(e) => {
+            onChangeContent(e.target.value);
+          }}
         />
       );
       break;
@@ -46,7 +48,9 @@ function ContentInput({ contentType, onChangeContent }: ContentInputProps) {
         <input
           type="string"
           id="content"
-          onChange={(e) => onChangeContent(e.target.value)}
+          onChange={(e) => {
+            onChangeContent(e.target.value);
+          }}
         />
       );
       break;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,9 @@ function AppRoot() {
   const [showApp, setShowApp] = useState(false);
   const [showCreateVFEForm, setShowCreateVFEForm] = useState(false);
   const [vfeData, setVFEData] = useState<VFE | null>(null);
+  const [currentPhotosphereID, setCurrentPhotosphereID] = useState(
+    vfeData ? vfeData.defaultPhotosphereID : "invalid",
+  );
 
   //Create a function to set useState true
   function handleLoadTestVFE() {
@@ -27,12 +30,20 @@ function AppRoot() {
 
   function loadCreatedVFE(data: VFE) {
     setVFEData(data);
+    setCurrentPhotosphereID(
+      currentPhotosphereID == "invalid"
+        ? data.defaultPhotosphereID
+        : currentPhotosphereID,
+    );
     setShowApp(true);
     setShowCreateVFEForm(false);
   }
 
-  function handleUpdateVFE(updatedVFE: VFE) {
+  function handleUpdateVFE(updatedVFE: VFE, currentPS?: string) {
     setVFEData(updatedVFE);
+    setCurrentPhotosphereID(
+      currentPS ? currentPS : updatedVFE.defaultPhotosphereID,
+    );
   }
 
   function renderComponent() {
@@ -40,7 +51,12 @@ function AppRoot() {
       return <CreateVFEForm onCreateVFE={loadCreatedVFE} />;
     } else if (vfeData && showApp) {
       return (
-        <PhotosphereEditor parentVFE={vfeData} onUpdateVFE={handleUpdateVFE} />
+        <PhotosphereEditor
+          currentPS={currentPhotosphereID}
+          onChangePS={setCurrentPhotosphereID}
+          parentVFE={vfeData}
+          onUpdateVFE={handleUpdateVFE}
+        />
       );
     } else if (!vfeData && showApp) {
       return <App />;

--- a/src/PhotosphereEditor.tsx
+++ b/src/PhotosphereEditor.tsx
@@ -51,8 +51,7 @@ function PhotosphereEditor({
   }
 
   function handleAddHotspot(newHotspot: Hotspot3D) {
-    // need to select correct photosphere
-    let photosphere: Photosphere = vfe.photospheres[currentPS];
+    const photosphere: Photosphere = vfe.photospheres[currentPS];
 
     photosphere.hotspots[newHotspot.tooltip] = newHotspot;
 

--- a/src/PhotosphereEditor.tsx
+++ b/src/PhotosphereEditor.tsx
@@ -14,6 +14,10 @@ import PhotosphereViewer from "./PhotosphereViewer.tsx";
     * Parent updates the VFE with the newPhotosphere object
    ----------------------------------------------------------------------- */
 
+function radToDeg(num: number): number {
+  return num * (180 / Math.PI);
+}
+
 // Properties passed down from parent
 interface PhotosphereEditorProps {
   currentPS: string;
@@ -33,7 +37,12 @@ function PhotosphereEditor({
   const [vfe, setVFE] = useState<VFE>(parentVFE);
   const [showAddPhotosphere, setShowAddPhotosphere] = useState(false);
   const [updateTrigger, setUpdateTrigger] = useState(0);
+
   const [showAddHotspot, setShowAddHotspot] = useState(false);
+  const [pitch, setPitch] = useState(0);
+  const [yaw, setYaw] = useState(0);
+
+  console.log(vfe);
 
   // Update the VFE
   function handleAddPhotosphere(newPhotosphere: Photosphere) {
@@ -61,10 +70,17 @@ function PhotosphereEditor({
     setUpdateTrigger((prev) => prev + 1);
   }
 
+  function handleLocation(vpitch: number, vyaw: number) {
+    setPitch(radToDeg(vpitch));
+    setYaw(radToDeg(vyaw));
+  }
+
   //Reset all states so we dont have issues with handling different components at the same time
   function resetStates() {
     setShowAddPhotosphere(false);
     setShowAddHotspot(false);
+    setPitch(0);
+    setYaw(0);
   }
 
   // This function is where we render the actual component based on the useState
@@ -74,7 +90,12 @@ function PhotosphereEditor({
     //Below this you will have your conditional for your own component, ie AddNavmap/AddHotspot
     if (showAddHotspot)
       return (
-        <AddHotspot onCancel={resetStates} onAddHotspot={handleAddHotspot} />
+        <AddHotspot
+          onCancel={resetStates}
+          onAddHotspot={handleAddHotspot}
+          pitch={pitch}
+          yaw={yaw}
+        />
       );
     return null;
   }
@@ -127,6 +148,7 @@ function PhotosphereEditor({
         <PhotosphereViewer
           currentPS={currentPS}
           onChangePS={onChangePS}
+          onViewerClick={handleLocation}
           key={updateTrigger}
           vfe={vfe}
         />

--- a/src/PhotosphereEditor.tsx
+++ b/src/PhotosphereEditor.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import AddHotspot from "./AddHotspot.tsx";
 import AddPhotosphere from "./AddPhotosphere.tsx";
-import { Photosphere, VFE } from "./DataStructures.ts";
+import { Hotspot3D, Photosphere, VFE } from "./DataStructures.ts";
 import PhotosphereViewer from "./PhotosphereViewer.tsx";
 
 /* -----------------------------------------------------------------------
@@ -16,12 +16,16 @@ import PhotosphereViewer from "./PhotosphereViewer.tsx";
 
 // Properties passed down from parent
 interface PhotosphereEditorProps {
+  currentPS: string;
+  onChangePS: (id: string) => void;
   parentVFE: VFE;
-  onUpdateVFE: (updatedVFE: VFE) => void;
+  onUpdateVFE: (updatedVFE: VFE, currentPS?: string) => void;
 }
 
 // If an update is triggered, add newPhotosphere, and update VFE
 function PhotosphereEditor({
+  currentPS,
+  onChangePS,
   parentVFE,
   onUpdateVFE,
 }: PhotosphereEditorProps): JSX.Element {
@@ -45,6 +49,19 @@ function PhotosphereEditor({
     setShowAddPhotosphere(false);
     setUpdateTrigger((prev) => prev + 1);
   }
+
+  function handleAddHotspot(newHotspot: Hotspot3D) {
+    // need to select correct photosphere
+    let photosphere: Photosphere = vfe.photospheres[currentPS];
+
+    photosphere.hotspots[newHotspot.tooltip] = newHotspot;
+
+    setVFE(vfe);
+    onUpdateVFE(vfe, currentPS);
+    setShowAddHotspot(false);
+    setUpdateTrigger((prev) => prev + 1);
+  }
+
   //Reset all states so we dont have issues with handling different components at the same time
   function resetStates() {
     setShowAddPhotosphere(false);
@@ -56,7 +73,10 @@ function PhotosphereEditor({
     if (showAddPhotosphere)
       return <AddPhotosphere onAddPhotosphere={handleAddPhotosphere} />;
     //Below this you will have your conditional for your own component, ie AddNavmap/AddHotspot
-    if (showAddHotspot) return <AddHotspot vfe={vfe} />;
+    if (showAddHotspot)
+      return (
+        <AddHotspot onCancel={resetStates} onAddHotspot={handleAddHotspot} />
+      );
     return null;
   }
   // Add styling for inputting information
@@ -105,7 +125,12 @@ function PhotosphereEditor({
         </button>
       </div>
       <div style={{ width: "100%", height: "100%" }}>
-        <PhotosphereViewer key={updateTrigger} vfe={vfe} />
+        <PhotosphereViewer
+          currentPS={currentPS}
+          onChangePS={onChangePS}
+          key={updateTrigger}
+          vfe={vfe}
+        />
         <ActiveComponent />
       </div>
     </div>

--- a/src/PhotosphereViewer.tsx
+++ b/src/PhotosphereViewer.tsx
@@ -125,7 +125,12 @@ function PhotosphereViewer(props: PhotosphereViewerProps) {
   const defaultPhotosphere =
     props.vfe.photospheres[props.vfe.defaultPhotosphereID];
   // conditional fixes popover not rendering on non-default photosphere problem
-  const [currentPhotosphere, setCurrentPhotosphere] = React.useState<Photosphere>(props.currentPS ? props.vfe.photospheres[props.currentPS] : defaultPhotosphere)
+  const [currentPhotosphere, setCurrentPhotosphere] =
+    React.useState<Photosphere>(
+      props.currentPS
+        ? props.vfe.photospheres[props.currentPS]
+        : defaultPhotosphere,
+    );
   const [hotspotArray, setHotspotArray] = useState<(Hotspot3D | Hotspot2D)[]>(
     [],
   );

--- a/src/PhotosphereViewer.tsx
+++ b/src/PhotosphereViewer.tsx
@@ -124,8 +124,8 @@ function PhotosphereViewer(props: PhotosphereViewerProps) {
   const photoSphereRef = React.createRef<ViewerAPI>();
   const defaultPhotosphere =
     props.vfe.photospheres[props.vfe.defaultPhotosphereID];
-  const [currentPhotosphere, setCurrentPhotosphere] =
-    React.useState<Photosphere>(defaultPhotosphere);
+  // conditional fixes popover not rendering on non-default photosphere problem
+  const [currentPhotosphere, setCurrentPhotosphere] = React.useState<Photosphere>(props.currentPS ? props.vfe.photospheres[props.currentPS] : defaultPhotosphere)
   const [hotspotArray, setHotspotArray] = useState<(Hotspot3D | Hotspot2D)[]>(
     [],
   );

--- a/src/PhotosphereViewer.tsx
+++ b/src/PhotosphereViewer.tsx
@@ -117,6 +117,7 @@ export interface PhotosphereViewerProps {
   vfe: VFE;
   currentPS?: string;
   onChangePS?: (id: string) => void;
+  onViewerClick?: (pitch: number, yaw: number) => void;
 }
 
 function PhotosphereViewer(props: PhotosphereViewerProps) {
@@ -159,6 +160,12 @@ function PhotosphereViewer(props: PhotosphereViewerProps) {
       const passMarker = currentPhotosphere.hotspots[marker.config.id];
 
       setHotspotArray([passMarker]);
+    });
+
+    instance.addEventListener("click", ({ data }) => {
+      if (!data.rightclick) {
+        props.onViewerClick?.(data.pitch, data.yaw);
+      }
     });
 
     const virtualTour =

--- a/src/PhotosphereViewer.tsx
+++ b/src/PhotosphereViewer.tsx
@@ -162,6 +162,8 @@ function PhotosphereViewer(props: PhotosphereViewerProps) {
     const markerTestPlugin: MarkersPlugin = instance.getPlugin(MarkersPlugin);
 
     markerTestPlugin.addEventListener("select-marker", ({ marker }) => {
+      if (marker.config.id.includes("__tour-link")) return;
+
       const passMarker = currentPhotosphere.hotspots[marker.config.id];
 
       setHotspotArray([passMarker]);

--- a/src/PhotosphereViewer.tsx
+++ b/src/PhotosphereViewer.tsx
@@ -115,6 +115,8 @@ function convertMap(map: NavMap, center: Point): MapPluginConfig {
 
 export interface PhotosphereViewerProps {
   vfe: VFE;
+  currentPS?: string;
+  onChangePS?: (id: string) => void;
 }
 
 function PhotosphereViewer(props: PhotosphereViewerProps) {
@@ -174,9 +176,14 @@ function PhotosphereViewer(props: PhotosphereViewerProps) {
       },
     );
 
-    virtualTour.setNodes(nodes, defaultPhotosphere.id);
+    // need to have conditional so that scene doesn't change when adding hotspots
+    virtualTour.setNodes(
+      nodes,
+      props.currentPS ? props.currentPS : defaultPhotosphere.id,
+    );
     virtualTour.addEventListener("node-changed", ({ node }) => {
       setCurrentPhotosphere(props.vfe.photospheres[node.id]);
+      props.onChangePS?.(node.id);
       setHotspotArray([]); // clear popovers on scene change
     });
 
@@ -189,6 +196,7 @@ function PhotosphereViewer(props: PhotosphereViewerProps) {
         setCurrentPhotosphere(
           props.vfe.photospheres[hotspot.data.photosphereID],
         );
+        props.onChangePS?.(hotspot.data.photosphereID);
       }
     });
   }
@@ -200,6 +208,7 @@ function PhotosphereViewer(props: PhotosphereViewerProps) {
         value={currentPhotosphere.id}
         setValue={(id) => {
           setCurrentPhotosphere(props.vfe.photospheres[id]);
+          props.onChangePS?.(id);
         }}
       />
 


### PR DESCRIPTION
Adds a hotspot to the currently viewed photosphere. 

Current clunkiness:
- Click for pitch/yaw clears other fields, need to click first then fill in tooltip, content, etc.
- ~~Clicking on a hotspot that was added to a non-default photosphere gives a blank white screen instead of content~~