### PR TITLE
Fix photosphere links

### DIFF
--- a/src/PhotosphereViewer.tsx
+++ b/src/PhotosphereViewer.tsx
@@ -154,6 +154,8 @@ function PhotosphereViewer(props: PhotosphereViewerProps) {
     const markerTestPlugin: MarkersPlugin = instance.getPlugin(MarkersPlugin);
 
     markerTestPlugin.addEventListener("select-marker", ({ marker }) => {
+      if (marker.config.id.includes("__tour-link")) return;
+
       const passMarker = currentPhotosphere.hotspots[marker.config.id];
 
       setHotspotArray([passMarker]);


### PR DESCRIPTION
Clicking on photosphere links in the main branch currently results in a white screen due to an error with hotspot IDs.

This fix is from the `AddHotspot` branch in @ashtonesawyer's PR (#44). It skips hotspot handling for photosphere links.