### PR TITLE
Add nav map button

### DIFF
--- a/src/AddNavmap.tsx
+++ b/src/AddNavmap.tsx
@@ -9,7 +9,7 @@ interface AddNavMapProps {
 
 function AddNavMap({ onCreateNavMap, onClose }: AddNavMapProps): JSX.Element {
   const [navmapName, setNavmapName] = useState("");
-  const [navmapImage, setNavmapImage] = useState<File | null>(null);
+  const [navmapImage, setNavmapImage] = useState<string | null>(null);
 
   function handleNameChange(e: React.ChangeEvent<HTMLInputElement>) {
     setNavmapName(e.target.value);
@@ -18,7 +18,11 @@ function AddNavMap({ onCreateNavMap, onClose }: AddNavMapProps): JSX.Element {
   function handleImageChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     if (file) {
-      setNavmapImage(file);
+      const reader = new FileReader();
+      reader.onloadend = function () {
+        setNavmapImage(reader.result as string);
+      };
+      reader.readAsDataURL(file);
     }
   }
 
@@ -28,7 +32,7 @@ function AddNavMap({ onCreateNavMap, onClose }: AddNavMapProps): JSX.Element {
       return;
     }
     const newNavMap: NavMap = {
-      src: URL.createObjectURL(navmapImage),
+      src: navmapImage,
       id: navmapName,
       rotation: 0,
       defaultZoom: 0,

--- a/src/AddNavmap.tsx
+++ b/src/AddNavmap.tsx
@@ -1,6 +1,88 @@
-function AddNavmap() {
-  // Placeholder content or logic can be added here later
-  return <></>;
+import React, { useState } from "react";
+
+import { NavMap } from "./DataStructures";
+
+interface AddNavMapProps {
+  onCreateNavMap: (navMap: NavMap) => void;
+  onClose: () => void; // Function to close the AddNavMap window
 }
 
-export default AddNavmap;
+function AddNavMap({ onCreateNavMap, onClose }: AddNavMapProps): JSX.Element {
+  const [navmapName, setNavmapName] = useState("");
+  const [navmapImage, setNavmapImage] = useState<File | null>(null);
+
+  function handleNameChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setNavmapName(e.target.value);
+  }
+
+  function handleImageChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) {
+      setNavmapImage(file);
+    }
+  }
+
+  function handleCreateNavMap() {
+    if (navmapName.trim() === "" || !navmapImage) {
+      alert("Please provide a name and select an image for the Nav Map.");
+      return;
+    }
+    const newNavMap: NavMap = {
+      src: URL.createObjectURL(navmapImage),
+      id: navmapName,
+      rotation: 0,
+      defaultZoom: 0,
+      hotspots: [],
+    };
+    onCreateNavMap(newNavMap); // Pass the new NavMap object directly
+    onClose(); // Close the AddNavMap window after creating the Nav Map
+  }
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        zIndex: 1050,
+        left: "50%",
+        top: "50%",
+        transform: "translate(-50%, -50%)",
+        background: "white",
+        borderRadius: "8px",
+        padding: "10px",
+        overflow: "hidden",
+      }}
+    >
+      <h1>Add New Nav Map</h1>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+        }}
+      >
+        <div>
+          <label htmlFor="navmapName">Nav Map Name:</label>
+          <input
+            type="text"
+            id="navmapName"
+            value={navmapName}
+            onChange={handleNameChange}
+          />
+        </div>
+        <div>
+          <label htmlFor="navmapImage">Upload Image:</label>
+          <input
+            type="file"
+            id="navmapImage"
+            accept="image/*"
+            onChange={handleImageChange}
+          />
+        </div>
+        <div>
+          <button onClick={handleCreateNavMap}>Create</button>
+          <button onClick={onClose}>Cancel</button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export default AddNavMap;

--- a/src/AddNavmap.tsx
+++ b/src/AddNavmap.tsx
@@ -7,6 +7,20 @@ interface AddNavMapProps {
   onClose: () => void; // Function to close the AddNavMap window
 }
 
+// Calculate image dimensions by creating an image element and waiting for it to load.
+// Since image loading isn't synchronous, it needs to be wrapped in a Promise.
+async function calculateImageDimensions(
+  url: string,
+): Promise<{ width: number; height: number }> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => {
+      resolve({ width: img.width, height: img.height });
+    };
+    img.src = url;
+  });
+}
+
 function AddNavMap({ onCreateNavMap, onClose }: AddNavMapProps): JSX.Element {
   const [navmapName, setNavmapName] = useState("");
   const [navmapImage, setNavmapImage] = useState<string | null>(null);
@@ -26,17 +40,22 @@ function AddNavMap({ onCreateNavMap, onClose }: AddNavMapProps): JSX.Element {
     }
   }
 
-  function handleCreateNavMap() {
+  async function handleCreateNavMap() {
     if (navmapName.trim() === "" || !navmapImage) {
       alert("Please provide a name and select an image for the Nav Map.");
       return;
     }
+
+    const navmapSize = 200;
+    const { width, height } = await calculateImageDimensions(navmapImage);
+    const maxDimension = Math.max(width, height);
     const newNavMap: NavMap = {
       src: navmapImage,
       id: navmapName,
       rotation: 0,
-      defaultZoom: 0,
-      hotspots: [],
+      defaultZoom: (navmapSize / maxDimension) * 100,
+      defaultCenter: { x: width / 2, y: height / 2 },
+      size: navmapSize,
     };
     onCreateNavMap(newNavMap); // Pass the new NavMap object directly
     onClose(); // Close the AddNavMap window after creating the Nav Map
@@ -81,7 +100,13 @@ function AddNavMap({ onCreateNavMap, onClose }: AddNavMapProps): JSX.Element {
           />
         </div>
         <div>
-          <button onClick={handleCreateNavMap}>Create</button>
+          <button
+            onClick={() => {
+              void handleCreateNavMap();
+            }}
+          >
+            Create
+          </button>
           <button onClick={onClose}>Cancel</button>
         </div>
       </form>

--- a/src/AddPhotosphere.tsx
+++ b/src/AddPhotosphere.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Photosphere } from "./DataStructures";
 
@@ -13,6 +13,59 @@ import { Photosphere } from "./DataStructures";
     * Pass it back to parent to update the VFE with the newPhotosphere
    ----------------------------------------------------------------------- */
 
+export interface PhotosphereCenterFormProps {
+  setPhotosphereCenter: (center: { x: number; y: number } | null) => void;
+}
+
+// Form inputs for setting the photosphere position on the map.
+export function PhotosphereCenterFieldset({
+  setPhotosphereCenter,
+}: PhotosphereCenterFormProps) {
+  const [photosphereCenterX, setPhotosphereCenterX] = useState("");
+  const [photosphereCenterY, setPhotosphereCenterY] = useState("");
+
+  useEffect(() => {
+    const center = {
+      x: parseFloat(photosphereCenterX),
+      y: parseFloat(photosphereCenterY),
+    };
+
+    if (!isNaN(center.x) && !isNaN(center.y)) {
+      setPhotosphereCenter(center);
+    } else {
+      setPhotosphereCenter(null);
+    }
+  }, [photosphereCenterX, photosphereCenterY, setPhotosphereCenter]);
+
+  return (
+    <fieldset>
+      <legend>Photosphere Map Position (Optional):</legend>
+      <div>
+        <label htmlFor="photosphereCenterX">X Coordinate:</label>
+        <input
+          type="number"
+          id="photosphereCenterX"
+          value={photosphereCenterX}
+          onChange={(e) => {
+            setPhotosphereCenterX(e.target.value);
+          }}
+        />
+      </div>
+      <div>
+        <label htmlFor="photosphereCenterY">Y Coordinate:</label>
+        <input
+          type="number"
+          id="photosphereCenterX"
+          value={photosphereCenterY}
+          onChange={(e) => {
+            setPhotosphereCenterY(e.target.value);
+          }}
+        />
+      </div>
+    </fieldset>
+  );
+}
+
 // Properties passed down from parent
 interface AddPhotosphereProps {
   onAddPhotosphere: (newPhotosphere: Photosphere) => void;
@@ -26,6 +79,10 @@ function AddPhotosphere({
   const [photosphereID, setPhotosphereID] = useState("");
   const [panoImage, setPanoImage] = useState("");
   const [audioFile, setAudioFile] = useState("");
+  const [photosphereCenter, setPhotosphereCenter] = useState<{
+    x: number;
+    y: number;
+  } | null>(null);
 
   // Add image data
   function handleImageChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -62,6 +119,7 @@ function AddPhotosphere({
     const newPhotosphere: Photosphere = {
       id: photosphereID,
       src: panoImage,
+      center: photosphereCenter ?? undefined,
       hotspots: {},
       backgroundAudio: audioFile,
     };
@@ -123,6 +181,9 @@ function AddPhotosphere({
             onChange={handleAudioChange}
           />
         </div>
+        <PhotosphereCenterFieldset
+          setPhotosphereCenter={setPhotosphereCenter}
+        />
         <button type="button" onClick={handlePhotosphereAdd}>
           Add Photosphere
         </button>

--- a/src/AddPhotosphere.tsx
+++ b/src/AddPhotosphere.tsx
@@ -62,7 +62,6 @@ function AddPhotosphere({
     const newPhotosphere: Photosphere = {
       id: photosphereID,
       src: panoImage,
-      center: { x: 0, y: 0 },
       hotspots: {},
       backgroundAudio: audioFile,
     };

--- a/src/AddPhotosphere.tsx
+++ b/src/AddPhotosphere.tsx
@@ -55,7 +55,7 @@ export function PhotosphereCenterFieldset({
         <label htmlFor="photosphereCenterY">Y Coordinate:</label>
         <input
           type="number"
-          id="photosphereCenterX"
+          id="photosphereCenterY"
           value={photosphereCenterY}
           onChange={(e) => {
             setPhotosphereCenterY(e.target.value);

--- a/src/CreateVFE.tsx
+++ b/src/CreateVFE.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 
+import { PhotosphereCenterFieldset } from "./AddPhotosphere.tsx";
 import { VFE } from "./DataStructures.ts";
 import PhotosphereViewer from "./PhotosphereViewer.tsx";
 
@@ -26,6 +27,10 @@ function CreateVFEForm({ onCreateVFE }: CreateVFEFormProps) {
   const [vfeName, setVFEName] = useState("");
   const [photosphereName, setPhotosphereName] = useState(""); // State for Photosphere Name
   const [panoImage, setPanoImage] = useState("");
+  const [photosphereCenter, setPhotosphereCenter] = useState<{
+    x: number;
+    y: number;
+  } | null>(null);
 
   // Error Handling: Ensure the data is not empty
   function handleCreateVFE() {
@@ -49,6 +54,7 @@ function CreateVFEForm({ onCreateVFE }: CreateVFEFormProps) {
         [photosphereName]: {
           id: photosphereName,
           src: panoImage,
+          center: photosphereCenter ?? undefined,
           hotspots: {},
         },
       },
@@ -95,6 +101,7 @@ function CreateVFEForm({ onCreateVFE }: CreateVFEFormProps) {
           }}
         />
       </div>
+      <PhotosphereCenterFieldset setPhotosphereCenter={setPhotosphereCenter} />
       <div>
         <label htmlFor="panoImage">Panorama Image:</label>
         <input

--- a/src/CreateVFE.tsx
+++ b/src/CreateVFE.tsx
@@ -41,14 +41,6 @@ function CreateVFEForm({ onCreateVFE }: CreateVFEFormProps) {
     // Input data into new VFE
     const data: VFE = {
       name: vfeName,
-      map: {
-        src: "",
-        id: "",
-        rotation: 0,
-        defaultZoom: 10,
-        defaultCenter: { x: 0, y: 0 },
-        size: 200,
-      },
       defaultPhotosphereID: photosphereName,
       photospheres: {
         [photosphereName]: {
@@ -101,7 +93,6 @@ function CreateVFEForm({ onCreateVFE }: CreateVFEFormProps) {
           }}
         />
       </div>
-      <PhotosphereCenterFieldset setPhotosphereCenter={setPhotosphereCenter} />
       <div>
         <label htmlFor="panoImage">Panorama Image:</label>
         <input
@@ -111,6 +102,7 @@ function CreateVFEForm({ onCreateVFE }: CreateVFEFormProps) {
           onChange={handleImageChange}
         />
       </div>
+      <PhotosphereCenterFieldset setPhotosphereCenter={setPhotosphereCenter} />
       <button onClick={handleCreateVFE}>Create VFE</button>
     </div>
   );

--- a/src/CreateVFE.tsx
+++ b/src/CreateVFE.tsx
@@ -38,6 +38,7 @@ function CreateVFEForm({ onCreateVFE }: CreateVFEFormProps) {
       name: vfeName,
       map: {
         src: "",
+        id: "",
         rotation: 0,
         defaultZoom: 0,
         hotspots: [],

--- a/src/CreateVFE.tsx
+++ b/src/CreateVFE.tsx
@@ -4,7 +4,7 @@ import { VFE } from "./DataStructures.ts";
 import PhotosphereViewer from "./PhotosphereViewer.tsx";
 
 /* -----------------------------------------------------------------------
-    Create a Virtual Field Environment (VFE) that will contain many 
+    Create a Virtual Field Environment (VFE) that will contain many
     Photospheres.
 
     * Props object allows us to send the new Photosphere back to parent
@@ -40,15 +40,15 @@ function CreateVFEForm({ onCreateVFE }: CreateVFEFormProps) {
         src: "",
         id: "",
         rotation: 0,
-        defaultZoom: 0,
-        hotspots: [],
+        defaultZoom: 10,
+        defaultCenter: { x: 0, y: 0 },
+        size: 200,
       },
       defaultPhotosphereID: photosphereName,
       photospheres: {
         [photosphereName]: {
           id: photosphereName,
           src: panoImage,
-          center: { x: 0, y: 0 },
           hotspots: {},
         },
       },

--- a/src/DataStructures.ts
+++ b/src/DataStructures.ts
@@ -21,7 +21,8 @@ export interface NavMap {
   id: string;
   rotation: number;
   defaultZoom: number;
-  hotspots: Hotspot2D[];
+  defaultCenter: { x: number; y: number };
+  size: number;
 }
 
 // Photosphere: a single 360-environment
@@ -29,7 +30,7 @@ export interface Photosphere {
   id: string;
   src: string;
   hotspots: Record<string, Hotspot3D>;
-  center: { x: number; y: number };
+  center?: { x: number; y: number };
   backgroundAudio?: string;
 }
 

--- a/src/DataStructures.ts
+++ b/src/DataStructures.ts
@@ -18,6 +18,7 @@ export interface VFE {
 // Navigation map: a birdseye view of the various hotspots within a single 360-environment
 export interface NavMap {
   src: string;
+  id: string;
   rotation: number;
   defaultZoom: number;
   hotspots: Hotspot2D[];

--- a/src/DataStructures.ts
+++ b/src/DataStructures.ts
@@ -10,7 +10,7 @@
 // Virtual Field Environment: the total collection of photosphere environments
 export interface VFE {
   name: string;
-  map: NavMap;
+  map?: NavMap;
   defaultPhotosphereID: string;
   photospheres: Record<string, Photosphere>;
 }

--- a/src/PhotosphereEditor.tsx
+++ b/src/PhotosphereEditor.tsx
@@ -151,7 +151,7 @@ function PhotosphereEditor({
             //Call your setShowAddNavmap function to set the state and display the function
           }}
         >
-          Add New NavMap
+          {vfe.map ? "Change NavMap" : "Add New NavMap"}
         </button>
         <button
           style={{ margin: "10px 0" }}

--- a/src/PhotosphereEditor.tsx
+++ b/src/PhotosphereEditor.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 
+import AddNavmap from "./AddNavmap";
 import AddPhotosphere from "./AddPhotosphere.tsx";
-import { Photosphere, VFE } from "./DataStructures.ts";
+import { NavMap, Photosphere, VFE } from "./DataStructures.ts";
 import PhotosphereViewer from "./PhotosphereViewer.tsx";
 
 /* -----------------------------------------------------------------------
@@ -28,6 +29,7 @@ function PhotosphereEditor({
   const [vfe, setVFE] = useState<VFE>(parentVFE);
   const [showAddPhotosphere, setShowAddPhotosphere] = useState(false);
   const [updateTrigger, setUpdateTrigger] = useState(0);
+  const [showAddNavMap, setShowAddNavMap] = useState(false); // State to manage whether to show AddNavmap
 
   // Update the VFE
   function handleAddPhotosphere(newPhotosphere: Photosphere) {
@@ -44,15 +46,31 @@ function PhotosphereEditor({
     setUpdateTrigger((prev) => prev + 1);
   }
 
+  function handleCreateNavMap(updatedNavMap: NavMap) {
+    const updatedVFE: VFE = {
+      ...vfe,
+      map: updatedNavMap,
+    };
+    setVFE(updatedVFE); // Update the local VFE state
+    onUpdateVFE(updatedVFE); // Propagate the change to the parent component
+    setShowAddNavMap(false); // Close the AddNavMap component
+  }
+
   // Reset all states so we dont have issues with handling different components at the same time
   function resetStates() {
     setShowAddPhotosphere(false);
+    setShowAddNavMap(false);
   }
 
+  
   // This function is where we render the actual component based on the useState
   function ActiveComponent() {
     if (showAddPhotosphere)
       return <AddPhotosphere onAddPhotosphere={handleAddPhotosphere} />;
+    if (showAddNavMap)
+      return (
+        <AddNavmap onCreateNavMap={handleCreateNavMap} onClose={resetStates} />
+      );
     // Below this you will have your conditional for your own component, ie AddNavmap/AddHotspot
     return null;
   }
@@ -85,6 +103,7 @@ function PhotosphereEditor({
           style={{ margin: "10px 0" }}
           onClick={() => {
             resetStates();
+            setShowAddNavMap(true); // Set state to show AddNavmap
             //Call your setShowAddNavmap function to set the state and display the function
           }}
         >

--- a/src/PhotosphereEditor.tsx
+++ b/src/PhotosphereEditor.tsx
@@ -69,6 +69,7 @@ function PhotosphereEditor({
     setVFE(updatedVFE); // Update the local VFE state
     onUpdateVFE(updatedVFE); // Propagate the change to the parent component
     setShowAddNavMap(false); // Close the AddNavMap component
+    setUpdateTrigger((prev) => prev + 1);
   }
 
   function handleAddHotspot(newHotspot: Hotspot3D) {

--- a/src/PhotosphereEditor.tsx
+++ b/src/PhotosphereEditor.tsx
@@ -56,7 +56,7 @@ function PhotosphereEditor({
       },
     };
     setVFE(updatedVFE); // Update the local VFE state
-    onUpdateVFE(updatedVFE); // Propagate the change to the AppRoot
+    onUpdateVFE(updatedVFE, newPhotosphere.id); // Propagate the change to the AppRoot
     setShowAddPhotosphere(false);
     setUpdateTrigger((prev) => prev + 1);
   }
@@ -67,7 +67,7 @@ function PhotosphereEditor({
       map: updatedNavMap,
     };
     setVFE(updatedVFE); // Update the local VFE state
-    onUpdateVFE(updatedVFE); // Propagate the change to the parent component
+    onUpdateVFE(updatedVFE, currentPS); // Propagate the change to the parent component
     setShowAddNavMap(false); // Close the AddNavMap component
     setUpdateTrigger((prev) => prev + 1);
   }

--- a/src/PhotosphereViewer.tsx
+++ b/src/PhotosphereViewer.tsx
@@ -128,6 +128,31 @@ function PhotosphereViewer(props: PhotosphereViewerProps) {
   );
 
   useEffect(() => {
+    const mapPlugin: MapPlugin | undefined =
+      photoSphereRef.current?.getPlugin(MapPlugin);
+
+    if (mapPlugin) {
+      const newMapConfig = convertMap(props.vfe.map, currentPhotosphere.center);
+
+      if (newMapConfig.imageUrl) {
+        mapPlugin.setImage(newMapConfig.imageUrl);
+      }
+
+      if (newMapConfig.center) {
+        mapPlugin.setCenter(newMapConfig.center);
+      }
+
+      if (newMapConfig.hotspots) {
+        mapPlugin.setHotspots(newMapConfig.hotspots);
+      }
+
+      if (newMapConfig.rotation !== undefined) {
+        mapPlugin.setOption("rotation", newMapConfig.rotation);
+      }
+    }
+  }, [props.vfe.map, currentPhotosphere.center, photoSphereRef]);
+
+  useEffect(() => {
     const virtualTour =
       photoSphereRef.current?.getPlugin<VirtualTourPlugin>(VirtualTourPlugin);
     void virtualTour?.setCurrentNode(currentPhotosphere.id);

--- a/src/PhotosphereViewer.tsx
+++ b/src/PhotosphereViewer.tsx
@@ -169,14 +169,7 @@ function PhotosphereViewer(props: PhotosphereViewerProps) {
 
   const plugins: ViewerConfig["plugins"] = [
     [MarkersPlugin, {}],
-    [
-      MapPlugin,
-      convertMap(
-        props.vfe.map,
-        props.vfe.photospheres,
-        defaultPhotosphere.center,
-      ),
-    ],
+
     [
       VirtualTourPlugin,
       {
@@ -187,6 +180,18 @@ function PhotosphereViewer(props: PhotosphereViewerProps) {
       } as VirtualTourPluginConfig,
     ],
   ];
+
+  // Only enable map plugin when VFE has a map
+  if (props.vfe.map) {
+    plugins.push([
+      MapPlugin,
+      convertMap(
+        props.vfe.map,
+        props.vfe.photospheres,
+        defaultPhotosphere.center,
+      ),
+    ]);
+  }
 
   function handleReady(instance: Viewer) {
     const markerTestPlugin: MarkersPlugin = instance.getPlugin(MarkersPlugin);

--- a/src/PhotosphereViewer.tsx
+++ b/src/PhotosphereViewer.tsx
@@ -1,4 +1,5 @@
 import { Point, Viewer, ViewerConfig } from "@photo-sphere-viewer/core";
+import { MapHotspot } from "@photo-sphere-viewer/map-plugin";
 import { MarkerConfig } from "@photo-sphere-viewer/markers-plugin";
 import {
   VirtualTourLink,
@@ -29,6 +30,11 @@ import PopOver from "./PopOver";
 /** Convert yaw/pitch degrees from numbers to strings ending in "deg" */
 function degToStr(val: number): string {
   return String(val) + "deg";
+}
+
+/** Convert sizes from numbers to strings ending in "px" */
+function sizeToStr(val: number): string {
+  return String(val) + "px";
 }
 
 /** Convert non-link hotspots to markers with type-based content/icons */
@@ -97,19 +103,34 @@ function convertLinks(hotspots: Record<string, Hotspot3D>): VirtualTourLink[] {
   return links;
 }
 
-function convertMap(map: NavMap, center: Point): MapPluginConfig {
+function convertMap(
+  map: NavMap,
+  photospheres: Record<string, Photosphere>,
+  currentCenter?: Point,
+): MapPluginConfig {
+  const hotspots: MapHotspot[] = [];
+
+  for (const [id, photosphere] of Object.entries(photospheres)) {
+    if (photosphere.center === undefined) continue;
+
+    hotspots.push({
+      id: id,
+      tooltip: id,
+      x: photosphere.center.x,
+      y: photosphere.center.y,
+      color: "yellow",
+    });
+  }
+
   return {
     imageUrl: map.src,
-    center,
+    center: currentCenter ?? map.defaultCenter,
     rotation: map.rotation,
     defaultZoom: map.defaultZoom,
-    hotspots: map.hotspots.map((hotspot) => ({
-      x: hotspot.x,
-      y: hotspot.y,
-      id: hotspot.id,
-      color: hotspot.color,
-      tooltip: hotspot.tooltip,
-    })),
+    minZoom: 1,
+    maxZoom: 100,
+    size: sizeToStr(map.size),
+    hotspots,
   };
 }
 
@@ -136,42 +157,26 @@ function PhotosphereViewer(props: PhotosphereViewerProps) {
   );
 
   useEffect(() => {
-    const mapPlugin: MapPlugin | undefined =
-      photoSphereRef.current?.getPlugin(MapPlugin);
-
-    if (mapPlugin) {
-      const newMapConfig = convertMap(props.vfe.map, currentPhotosphere.center);
-
-      if (newMapConfig.imageUrl) {
-        mapPlugin.setImage(newMapConfig.imageUrl);
-      }
-
-      if (newMapConfig.center) {
-        mapPlugin.setCenter(newMapConfig.center);
-      }
-
-      if (newMapConfig.hotspots) {
-        mapPlugin.setHotspots(newMapConfig.hotspots);
-      }
-
-      if (newMapConfig.rotation !== undefined) {
-        mapPlugin.setOption("rotation", newMapConfig.rotation);
-      }
-    }
-  }, [props.vfe.map, currentPhotosphere.center, photoSphereRef]);
-
-  useEffect(() => {
     const virtualTour =
       photoSphereRef.current?.getPlugin<VirtualTourPlugin>(VirtualTourPlugin);
     void virtualTour?.setCurrentNode(currentPhotosphere.id);
 
     const map = photoSphereRef.current?.getPlugin<MapPlugin>(MapPlugin);
-    map?.setCenter(currentPhotosphere.center);
+    if (currentPhotosphere.center) {
+      map?.setCenter(currentPhotosphere.center);
+    }
   }, [currentPhotosphere, photoSphereRef]);
 
   const plugins: ViewerConfig["plugins"] = [
     [MarkersPlugin, {}],
-    [MapPlugin, convertMap(props.vfe.map, defaultPhotosphere.center)],
+    [
+      MapPlugin,
+      convertMap(
+        props.vfe.map,
+        props.vfe.photospheres,
+        defaultPhotosphere.center,
+      ),
+    ],
     [
       VirtualTourPlugin,
       {
@@ -228,15 +233,9 @@ function PhotosphereViewer(props: PhotosphereViewerProps) {
 
     const map = instance.getPlugin<MapPlugin>(MapPlugin);
     map.addEventListener("select-hotspot", ({ hotspotId }) => {
-      const hotspot: Hotspot2D | undefined = props.vfe.map.hotspots.find(
-        (hotspot) => hotspot.id === hotspotId,
-      );
-      if (hotspot?.data.tag === "PhotosphereLink") {
-        setCurrentPhotosphere(
-          props.vfe.photospheres[hotspot.data.photosphereID],
-        );
-        props.onChangePS?.(hotspot.data.photosphereID);
-      }
+      const photosphere = props.vfe.photospheres[hotspotId];
+      setCurrentPhotosphere(photosphere);
+      props.onChangePS?.(photosphere.id);
     });
   }
 

--- a/src/Prototype.tsx
+++ b/src/Prototype.tsx
@@ -326,16 +326,8 @@ function App() {
     src: mapImage,
     rotation: 0,
     defaultZoom: 20,
-    hotspots: Object.values(photospheres).map((p) => {
-      return {
-        x: p.center.x,
-        y: p.center.y,
-        id: p.id,
-        color: "yellow",
-        tooltip: p.id,
-        data: { tag: "PhotosphereLink", photosphereID: p.id },
-      };
-    }),
+    defaultCenter: { x: 0, y: 0 },
+    size: 200,
   };
 
   const data: VFE = {

--- a/src/Prototype.tsx
+++ b/src/Prototype.tsx
@@ -322,6 +322,7 @@ function App() {
   };
 
   const map: NavMap = {
+    id: "navmap",
     src: mapImage,
     rotation: 0,
     defaultZoom: 20,


### PR DESCRIPTION
This PR adds the "add navmap" button to the photosphere editor.

The main change to the data structure is that the map no longer stores a list of hotspots. Hotspots are automatically generated from the collection photospheres and their associated positions on the map.

When creating the VFE or add new photosphere, there is now a way to give their position on the map at the same time. Currently, it requires entering x and y coordinates manually. In a future PR, there should be a way to click on the image to get the coordinates.
