### PR TITLE
Add React Router routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "@mui/material": "^5.15.14",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-photo-sphere-viewer": "^4.2.1-psv5.6.0"
+        "react-photo-sphere-viewer": "^4.2.1-psv5.6.0",
+        "react-router-dom": "^6.22.3"
       },
       "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
@@ -1508,6 +1509,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.3.tgz",
+      "integrity": "sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -4808,6 +4817,36 @@
       "engines": {
         "node": ">=8",
         "npm": ">=5"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.3.tgz",
+      "integrity": "sha512-dr2eb3Mj5zK2YISHK++foM9w4eBnO23eKnZEDs7c880P6oKbrjz/Svg9+nxqtHQK+oMW4OtjZca0RqPglXxguQ==",
+      "dependencies": {
+        "@remix-run/router": "1.15.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.3.tgz",
+      "integrity": "sha512-7ZILI7HjcE+p31oQvwbokjk6OA/bnFxrhJ19n82Ex9Ph8fNAq+Hm/7KchpMGlTgWhUxRHMMCut+vEtNpWpowKw==",
+      "dependencies": {
+        "@remix-run/router": "1.15.3",
+        "react-router": "6.22.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "@mui/material": "^5.15.14",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-photo-sphere-viewer": "^4.2.1-psv5.6.0"
+    "react-photo-sphere-viewer": "^4.2.1-psv5.6.0",
+    "react-router-dom": "^6.22.3"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Navigate, Route, Routes, useNavigate } from "react-router-dom";
 
 import CreateVFEForm from "./CreateVFE.tsx";
 import { VFE } from "./DataStructures.ts";
@@ -10,22 +11,20 @@ import App from "./Prototype.tsx";
 // Should decide what we are doing, going to LandingPage/Rendering VFE
 function AppRoot() {
   // Decide state, should manage whether the VFE should be displayed or the LandingPage should be displayed
-  const [showApp, setShowApp] = useState(false);
-  const [showCreateVFEForm, setShowCreateVFEForm] = useState(false);
   const [vfeData, setVFEData] = useState<VFE | null>(null);
   const [currentPhotosphereID, setCurrentPhotosphereID] = useState(
     vfeData ? vfeData.defaultPhotosphereID : "invalid",
   );
 
+  const navigate = useNavigate();
+
   //Create a function to set useState true
   function handleLoadTestVFE() {
-    setShowApp(true);
-    setShowCreateVFEForm(false);
+    navigate("/viewer");
   }
 
   function handleCreateVFE() {
-    setShowCreateVFEForm(true);
-    setShowApp(false);
+    navigate("/create");
   }
 
   function loadCreatedVFE(data: VFE) {
@@ -35,8 +34,7 @@ function AppRoot() {
         ? data.defaultPhotosphereID
         : currentPhotosphereID,
     );
-    setShowApp(true);
-    setShowCreateVFEForm(false);
+    navigate("/editor");
   }
 
   function handleUpdateVFE(updatedVFE: VFE, currentPS?: string) {
@@ -46,31 +44,40 @@ function AppRoot() {
     );
   }
 
-  function renderComponent() {
-    if (showCreateVFEForm) {
-      return <CreateVFEForm onCreateVFE={loadCreatedVFE} />;
-    } else if (vfeData && showApp) {
-      return (
-        <PhotosphereEditor
-          currentPS={currentPhotosphereID}
-          onChangePS={setCurrentPhotosphereID}
-          parentVFE={vfeData}
-          onUpdateVFE={handleUpdateVFE}
-        />
-      );
-    } else if (!vfeData && showApp) {
-      return <App />;
-    } else {
-      return (
-        <LandingPage
-          onLoadTestVFE={handleLoadTestVFE}
-          onCreateVFE={handleCreateVFE}
-        />
-      );
-    }
-  }
-
-  return <div>{renderComponent()}</div>;
+  return (
+    <Routes>
+      <Route
+        index
+        element={
+          <LandingPage
+            onLoadTestVFE={handleLoadTestVFE}
+            onCreateVFE={handleCreateVFE}
+          />
+        }
+      />
+      <Route path="/viewer" element={<App />} />
+      <Route
+        path="/create"
+        element={<CreateVFEForm onCreateVFE={loadCreatedVFE} />}
+      />
+      <Route
+        path="/editor"
+        element={
+          vfeData ? (
+            <PhotosphereEditor
+              currentPS={currentPhotosphereID}
+              onChangePS={setCurrentPhotosphereID}
+              parentVFE={vfeData}
+              onUpdateVFE={handleUpdateVFE}
+            />
+          ) : (
+            // redirect back to the create form if VFE hasn't been created yet
+            <Navigate to="/create" replace={true} />
+          )
+        }
+      />
+    </Routes>
+  );
 }
 
 export default AppRoot;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { ThemeProvider } from "@emotion/react";
 import { createTheme } from "@mui/material";
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 
 import AppRoot from "./App.tsx";
 import "./index.css";
@@ -18,9 +19,11 @@ const rootElement = document.getElementById("root");
 if (rootElement) {
   ReactDOM.createRoot(rootElement).render(
     <React.StrictMode>
-      <ThemeProvider theme={theme}>
-        <AppRoot /> {/* Updated component reference */}
-      </ThemeProvider>
+      <BrowserRouter>
+        <ThemeProvider theme={theme}>
+          <AppRoot /> {/* Updated component reference */}
+        </ThemeProvider>
+      </BrowserRouter>
     </React.StrictMode>,
   );
 } else {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "rewrites": [
+    { "source": "/viewer", "destination": "/" },
+    { "source": "/create", "destination": "/" },
+    { "source": "/editor", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
This PR adds the React Router dependency with the following routes:
* `/` (index) renders the landing page.
* `/viewer` renders the viewer with the prototype VFE.
* `/create` renders the create VFE form.
* `/editor` renders the editor if a VFE has been created. Otherwise, it automatically redirects to `/create`.

I had to add a `vercel.json` config file so it's possible to visit the routes directly. Without that file, going to a route by typing it in the URL bar would result in a 404.

Closes #38