### PR TITLE
Include VFE/Photospheres IDs in Viewer/Editor Routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,7 +51,7 @@ function AppRoot() {
         element={<Prototype />}
       />
       <Route path="/viewer/:vfeID" element={<PhotosphereLoader />}>
-        <Route path=":photosphereID" element={<></>} />
+        <Route path=":photosphereID" element={null} />
       </Route>
       <Route
         path="/create"
@@ -76,7 +76,7 @@ function AppRoot() {
           )
         }
       >
-        <Route path=":photosphereID" element={<></>} />
+        <Route path=":photosphereID" element={null} />
       </Route>
     </Routes>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,9 +13,6 @@ import Prototype from "./Prototype.tsx";
 function AppRoot() {
   // Decide state, should manage whether the VFE should be displayed or the LandingPage should be displayed
   const [vfeData, setVFEData] = useState<VFE | null>(null);
-  const [currentPhotosphereID, setCurrentPhotosphereID] = useState(
-    vfeData ? vfeData.defaultPhotosphereID : "invalid",
-  );
 
   const navigate = useNavigate();
 
@@ -30,19 +27,11 @@ function AppRoot() {
 
   function loadCreatedVFE(data: VFE) {
     setVFEData(data);
-    setCurrentPhotosphereID(
-      currentPhotosphereID == "invalid"
-        ? data.defaultPhotosphereID
-        : currentPhotosphereID,
-    );
-    navigate("/editor");
+    navigate(`/editor/${data.name}/${data.defaultPhotosphereID}`);
   }
 
-  function handleUpdateVFE(updatedVFE: VFE, currentPS?: string) {
+  function handleUpdateVFE(updatedVFE: VFE) {
     setVFEData(updatedVFE);
-    setCurrentPhotosphereID(
-      currentPS ? currentPS : updatedVFE.defaultPhotosphereID,
-    );
   }
 
   return (
@@ -56,7 +45,11 @@ function AppRoot() {
           />
         }
       />
-      <Route path="/viewer" element={<Prototype />} />
+      <Route
+        path="/viewer"
+        // TODO: replace with a way to select a VFE from a list
+        element={<Prototype />}
+      />
       <Route path="/viewer/:vfeID" element={<PhotosphereLoader />}>
         <Route path=":sceneID" element={<></>} />
       </Route>
@@ -66,11 +59,14 @@ function AppRoot() {
       />
       <Route
         path="/editor"
+        // TODO: replace with a way to select a VFE from a list
+        element={<Navigate to="/create" replace={true} />}
+      />
+      <Route
+        path="/editor/:vfeID"
         element={
           vfeData ? (
             <PhotosphereEditor
-              currentPS={currentPhotosphereID}
-              onChangePS={setCurrentPhotosphereID}
               parentVFE={vfeData}
               onUpdateVFE={handleUpdateVFE}
             />
@@ -79,7 +75,9 @@ function AppRoot() {
             <Navigate to="/create" replace={true} />
           )
         }
-      />
+      >
+        <Route path=":sceneID" element={<></>} />
+      </Route>
     </Routes>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,8 @@ import CreateVFEForm from "./CreateVFE.tsx";
 import { VFE } from "./DataStructures.ts";
 import LandingPage from "./LandingPage.tsx";
 import PhotosphereEditor from "./PhotosphereEditor.tsx";
-import App from "./Prototype.tsx";
+import PhotosphereLoader from "./PhotosphereLoader.tsx";
+import Prototype from "./Prototype.tsx";
 
 // Main component acts as a main entry point for the application
 // Should decide what we are doing, going to LandingPage/Rendering VFE
@@ -55,7 +56,10 @@ function AppRoot() {
           />
         }
       />
-      <Route path="/viewer" element={<App />} />
+      <Route path="/viewer" element={<Prototype />} />
+      <Route path="/viewer/:vfeID" element={<PhotosphereLoader />}>
+        <Route path=":sceneID" />
+      </Route>
       <Route
         path="/create"
         element={<CreateVFEForm onCreateVFE={loadCreatedVFE} />}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,7 +51,7 @@ function AppRoot() {
         element={<Prototype />}
       />
       <Route path="/viewer/:vfeID" element={<PhotosphereLoader />}>
-        <Route path=":sceneID" element={<></>} />
+        <Route path=":photosphereID" element={<></>} />
       </Route>
       <Route
         path="/create"
@@ -76,7 +76,7 @@ function AppRoot() {
           )
         }
       >
-        <Route path=":sceneID" element={<></>} />
+        <Route path=":photosphereID" element={<></>} />
       </Route>
     </Routes>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,7 +58,7 @@ function AppRoot() {
       />
       <Route path="/viewer" element={<Prototype />} />
       <Route path="/viewer/:vfeID" element={<PhotosphereLoader />}>
-        <Route path=":sceneID" />
+        <Route path=":sceneID" element={<></>} />
       </Route>
       <Route
         path="/create"

--- a/src/CreateVFE.tsx
+++ b/src/CreateVFE.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 
 import { PhotosphereCenterFieldset } from "./AddPhotosphere.tsx";
 import { VFE } from "./DataStructures.ts";
-import PhotosphereViewer from "./PhotosphereViewer.tsx";
 
 /* -----------------------------------------------------------------------
     Create a Virtual Field Environment (VFE) that will contain many
@@ -52,7 +51,6 @@ function CreateVFEForm({ onCreateVFE }: CreateVFEFormProps) {
       },
     };
     onCreateVFE(data);
-    return <PhotosphereViewer vfe={data} />;
   }
 
   // Ensure file is truthy

--- a/src/PhotosphereEditor.tsx
+++ b/src/PhotosphereEditor.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
 
 import AddHotspot from "./AddHotspot.tsx";
 import AddNavmap from "./AddNavmap";
@@ -21,19 +22,18 @@ function radToDeg(num: number): number {
 
 // Properties passed down from parent
 interface PhotosphereEditorProps {
-  currentPS: string;
-  onChangePS: (id: string) => void;
   parentVFE: VFE;
-  onUpdateVFE: (updatedVFE: VFE, currentPS?: string) => void;
+  onUpdateVFE: (updatedVFE: VFE) => void;
 }
 
 // If an update is triggered, add newPhotosphere, and update VFE
 function PhotosphereEditor({
-  currentPS,
-  onChangePS,
   parentVFE,
   onUpdateVFE,
 }: PhotosphereEditorProps): JSX.Element {
+  const { sceneID } = useParams() as { vfeID: string; sceneID: string };
+  const navigate = useNavigate();
+
   // Base states
   const [vfe, setVFE] = useState<VFE>(parentVFE);
   const [showAddPhotosphere, setShowAddPhotosphere] = useState(false);
@@ -46,6 +46,11 @@ function PhotosphereEditor({
 
   console.log(vfe);
 
+  // Change URL to reflect current photosphere
+  function onChangePS(id: string) {
+    navigate(id, { replace: true });
+  }
+
   // Update the VFE
   function handleAddPhotosphere(newPhotosphere: Photosphere) {
     const updatedVFE: VFE = {
@@ -56,7 +61,8 @@ function PhotosphereEditor({
       },
     };
     setVFE(updatedVFE); // Update the local VFE state
-    onUpdateVFE(updatedVFE, newPhotosphere.id); // Propagate the change to the AppRoot
+    onUpdateVFE(updatedVFE); // Propagate the change to the AppRoot
+    onChangePS(newPhotosphere.id); // Switch to new photosphere
     setShowAddPhotosphere(false);
     setUpdateTrigger((prev) => prev + 1);
   }
@@ -67,18 +73,18 @@ function PhotosphereEditor({
       map: updatedNavMap,
     };
     setVFE(updatedVFE); // Update the local VFE state
-    onUpdateVFE(updatedVFE, currentPS); // Propagate the change to the parent component
+    onUpdateVFE(updatedVFE); // Propagate the change to the parent component
     setShowAddNavMap(false); // Close the AddNavMap component
     setUpdateTrigger((prev) => prev + 1);
   }
 
   function handleAddHotspot(newHotspot: Hotspot3D) {
-    const photosphere: Photosphere = vfe.photospheres[currentPS];
+    const photosphere: Photosphere = vfe.photospheres[sceneID];
 
     photosphere.hotspots[newHotspot.tooltip] = newHotspot;
 
     setVFE(vfe);
-    onUpdateVFE(vfe, currentPS);
+    onUpdateVFE(vfe);
     setShowAddHotspot(false);
     setUpdateTrigger((prev) => prev + 1);
   }
@@ -166,7 +172,7 @@ function PhotosphereEditor({
       </div>
       <div style={{ width: "100%", height: "100%" }}>
         <PhotosphereViewer
-          currentPS={currentPS}
+          currentPS={sceneID}
           onChangePS={onChangePS}
           onViewerClick={handleLocation}
           key={updateTrigger}

--- a/src/PhotosphereEditor.tsx
+++ b/src/PhotosphereEditor.tsx
@@ -31,7 +31,10 @@ function PhotosphereEditor({
   parentVFE,
   onUpdateVFE,
 }: PhotosphereEditorProps): JSX.Element {
-  const { sceneID } = useParams() as { vfeID: string; sceneID: string };
+  const { photosphereID } = useParams() as {
+    vfeID: string;
+    photosphereID: string;
+  };
   const navigate = useNavigate();
 
   // Base states
@@ -79,7 +82,7 @@ function PhotosphereEditor({
   }
 
   function handleAddHotspot(newHotspot: Hotspot3D) {
-    const photosphere: Photosphere = vfe.photospheres[sceneID];
+    const photosphere: Photosphere = vfe.photospheres[photosphereID];
 
     photosphere.hotspots[newHotspot.tooltip] = newHotspot;
 
@@ -172,7 +175,7 @@ function PhotosphereEditor({
       </div>
       <div style={{ width: "100%", height: "100%" }}>
         <PhotosphereViewer
-          currentPS={sceneID}
+          currentPS={photosphereID}
           onChangePS={onChangePS}
           onViewerClick={handleLocation}
           key={updateTrigger}

--- a/src/PhotosphereLoader.tsx
+++ b/src/PhotosphereLoader.tsx
@@ -1,10 +1,11 @@
 import { Alert, Stack } from "@mui/material";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 import { VFE } from "./DataStructures";
 import PhotosphereViewer from "./PhotosphereViewer";
 
 function PhotosphereLoader() {
+  const navigate = useNavigate();
   const { vfeID, photosphereID } = useParams() as {
     vfeID: string;
     photosphereID?: string;
@@ -26,9 +27,9 @@ function PhotosphereLoader() {
   return (
     <PhotosphereViewer
       vfe={data}
-      currentPS={photosphereID}
+      currentPS={photosphereID ?? data.defaultPhotosphereID}
       onChangePS={(id) => {
-        history.replaceState(null, "", id); // change path without forcing a rerender
+        navigate(id, { replace: true });
       }}
     />
   );

--- a/src/PhotosphereLoader.tsx
+++ b/src/PhotosphereLoader.tsx
@@ -5,7 +5,10 @@ import { VFE } from "./DataStructures";
 import PhotosphereViewer from "./PhotosphereViewer";
 
 function PhotosphereLoader() {
-  const { vfeID, sceneID } = useParams() as { vfeID: string; sceneID?: string };
+  const { vfeID, photosphereID } = useParams() as {
+    vfeID: string;
+    photosphereID?: string;
+  };
 
   const vfeData = window.localStorage.getItem(vfeID);
 
@@ -23,7 +26,7 @@ function PhotosphereLoader() {
   return (
     <PhotosphereViewer
       vfe={data}
-      currentPS={sceneID}
+      currentPS={photosphereID}
       onChangePS={(id) => {
         history.replaceState(null, "", id); // change path without forcing a rerender
       }}

--- a/src/PhotosphereLoader.tsx
+++ b/src/PhotosphereLoader.tsx
@@ -1,0 +1,34 @@
+import { Alert, Stack } from "@mui/material";
+import { useParams } from "react-router-dom";
+
+import { VFE } from "./DataStructures";
+import PhotosphereViewer from "./PhotosphereViewer";
+
+function PhotosphereLoader() {
+  const { vfeID, sceneID } = useParams() as { vfeID: string; sceneID?: string };
+
+  const vfeData = window.localStorage.getItem(vfeID);
+
+  if (!vfeData) {
+    return (
+      <Stack minHeight="100vh" alignItems="center" justifyContent="center">
+        <Alert variant="filled" severity="error">
+          Failed to load stored VFE data.
+        </Alert>
+      </Stack>
+    );
+  }
+
+  const data = JSON.parse(vfeData) as VFE;
+  return (
+    <PhotosphereViewer
+      vfe={data}
+      currentPS={sceneID}
+      onChangePS={(id) => {
+        history.replaceState(null, "", id); // change path without forcing a rerender
+      }}
+    />
+  );
+}
+
+export default PhotosphereLoader;

--- a/src/PhotosphereViewer.tsx
+++ b/src/PhotosphereViewer.tsx
@@ -179,19 +179,19 @@ function PhotosphereViewer(props: PhotosphereViewerProps) {
         },
       } as VirtualTourPluginConfig,
     ],
-  ];
 
-  // Only enable map plugin when VFE has a map
-  if (props.vfe.map) {
-    plugins.push([
+    // Only fill map plugin config when VFE has a map
+    [
       MapPlugin,
-      convertMap(
-        props.vfe.map,
-        props.vfe.photospheres,
-        defaultPhotosphere.center,
-      ),
-    ]);
-  }
+      props.vfe.map
+        ? convertMap(
+            props.vfe.map,
+            props.vfe.photospheres,
+            defaultPhotosphere.center,
+          )
+        : {},
+    ],
+  ];
 
   function handleReady(instance: Viewer) {
     const markerTestPlugin: MarkersPlugin = instance.getPlugin(MarkersPlugin);

--- a/src/PhotosphereViewer.tsx
+++ b/src/PhotosphereViewer.tsx
@@ -199,9 +199,13 @@ function PhotosphereViewer(props: PhotosphereViewerProps) {
     markerTestPlugin.addEventListener("select-marker", ({ marker }) => {
       if (marker.config.id.includes("__tour-link")) return;
 
-      const passMarker = currentPhotosphere.hotspots[marker.config.id];
-
-      setHotspotArray([passMarker]);
+      // setCurrentPhotosphere has to be used to get the current state value because
+      // the value of currentPhotosphere does not get updated in an event listener
+      setCurrentPhotosphere((currentState) => {
+        const passMarker = currentState.hotspots[marker.config.id];
+        setHotspotArray([passMarker]);
+        return currentState;
+      });
     });
 
     instance.addEventListener("click", ({ data }) => {

--- a/src/Prototype.tsx
+++ b/src/Prototype.tsx
@@ -1,25 +1,11 @@
-import { Alert, Stack } from "@mui/material";
+import { Navigate } from "react-router-dom";
 
-import { VFE } from "./DataStructures.ts";
-import PhotosphereViewer from "./PhotosphereViewer.tsx";
 import dataArray from "./data.json";
 
-function App() {
-  window.localStorage.setItem("vfeData", JSON.stringify(dataArray));
-  const vfeData = window.localStorage.getItem("vfeData");
+function Prototype() {
+  window.localStorage.setItem("prototype", JSON.stringify(dataArray));
 
-  if (!vfeData) {
-    return (
-      <Stack minHeight="100vh" alignItems="center" justifyContent="center">
-        <Alert variant="filled" severity="error">
-          Failed to load stored VFE data.
-        </Alert>
-      </Stack>
-    );
-  }
-
-  const data = JSON.parse(vfeData) as VFE;
-  return <PhotosphereViewer vfe={data} />;
+  return <Navigate to="/viewer/prototype/" replace={true} />;
 }
 
-export default App;
+export default Prototype;

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,3 @@
 {
-  "rewrites": [
-    { "source": "/viewer", "destination": "/" },
-    { "source": "/create", "destination": "/" },
-    { "source": "/editor", "destination": "/" }
-  ]
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
 }


### PR DESCRIPTION
This PR adds more route handling so the full viewer URL is now `/viewer/(VFE ID)/(Photosphere ID)` and the full editor URL is `/editor/(VFE ID)/(Photosphere ID)`.

The photosphere ID is optional for the viewer URL, it defaults to the defaultPhotosphereID if not specified. The viewer URL currently reads a VFE from localStorage, while the editor URL still uses the in-memory VFE data.