### PR TITLE
Support Editing Photosphere Link Hotspots

### DIFF
--- a/src/DataStructures.ts
+++ b/src/DataStructures.ts
@@ -11,6 +11,10 @@ export function newID() {
   return crypto.randomUUID();
 }
 
+export function photosphereLinkTooltip(photosphereID: string) {
+  return `Go to ${photosphereID}`;
+}
+
 // Calculate image dimensions by creating an image element and waiting for it to load.
 // Since image loading isn't synchronous, it needs to be wrapped in a Promise.
 export async function calculateImageDimensions(

--- a/src/HotspotEditor.tsx
+++ b/src/HotspotEditor.tsx
@@ -9,7 +9,6 @@ import {
   ExpandLess,
   ExpandMore,
   Image,
-  Landscape,
   Quiz,
   Title,
   Videocam,
@@ -37,6 +36,7 @@ import {
 import Box from "@mui/material/Box";
 
 import { Asset, Hotspot2D, HotspotData, newID } from "./DataStructures";
+import { LinkArrowIcon } from "./LinkArrowIcon";
 import { HotspotDataEditor, HotspotIconEditor } from "./buttons/AddHotspot";
 
 export interface HotspotIconProps {
@@ -46,7 +46,7 @@ export interface HotspotIconProps {
 }
 
 export function HotspotIcon({ hotspotData, color, icon }: HotspotIconProps) {
-  if (icon) {
+  if (icon && hotspotData.tag !== "PhotosphereLink") {
     return <img src={icon.path} height={24} />;
   }
 
@@ -67,7 +67,7 @@ export function HotspotIcon({ hotspotData, color, icon }: HotspotIconProps) {
     case "Quiz":
       return <Quiz sx={iconProps} />;
     case "PhotosphereLink":
-      return <Landscape sx={iconProps} />;
+      return <LinkArrowIcon color={color} size={24} />;
   }
 }
 

--- a/src/HotspotEditor.tsx
+++ b/src/HotspotEditor.tsx
@@ -35,7 +35,13 @@ import {
 } from "@mui/material";
 import Box from "@mui/material/Box";
 
-import { Asset, Hotspot2D, HotspotData, newID } from "./DataStructures";
+import {
+  Asset,
+  Hotspot2D,
+  HotspotData,
+  newID,
+  photosphereLinkTooltip,
+} from "./DataStructures";
 import { LinkArrowIcon } from "./LinkArrowIcon";
 import { HotspotDataEditor, HotspotIconEditor } from "./buttons/AddHotspot";
 
@@ -387,6 +393,14 @@ function HotspotEditor({
       ? Object.values(previewData.hotspots).length
       : 0;
 
+  function updateData(newData: HotspotData | null) {
+    setPreviewData(newData);
+    if (newData?.tag === "PhotosphereLink") {
+      setPreviewTooltip(photosphereLinkTooltip(newData.photosphereID));
+    }
+    setEdited(true);
+  }
+
   function removeNestedHotspot(hotspotID: string) {
     if (previewData?.tag === "Image") {
       const { [hotspotID]: _removed, ...remainingHotspots } =
@@ -420,21 +434,22 @@ function HotspotEditor({
         <Typography variant="h5">Hotspot Editor</Typography>
       </Stack>
 
-      <TextField
-        label="Tooltip"
-        value={previewTooltip}
-        onChange={(e) => {
-          setPreviewTooltip(e.target.value);
-          setEdited(true);
-        }}
-      />
+      {previewData?.tag !== "PhotosphereLink" && (
+        <TextField
+          label="Tooltip"
+          value={previewTooltip}
+          onChange={(e) => {
+            setPreviewTooltip(e.target.value);
+            setEdited(true);
+          }}
+        />
+      )}
+
       <HotspotDataEditor
         hotspotData={previewData}
-        setHotspotData={(data) => {
-          setPreviewData(data);
-          setEdited(true);
-        }}
+        setHotspotData={updateData}
       />
+
       {setPreviewIcon && (
         <HotspotIconEditor
           iconAsset={previewIcon}

--- a/src/LinkArrowIcon.tsx
+++ b/src/LinkArrowIcon.tsx
@@ -1,0 +1,49 @@
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+
+// SVG Path from https://github.com/mistic100/Photo-Sphere-Viewer/blob/5.7.4/packages/virtual-tour-plugin/src/arrow.svg?short_path=250fbf4
+const arrowIconPath = `M50,50 m45,0
+a45,45 0 1,0 -90,0
+a45,45 0 1,0  90,0
+
+M50,50 m38,0
+a38,38 0 0,1 -76,0
+a38,38 0 0,1  76,0
+
+M50,50 m30,0
+a30,30 0 1,0 -60,0
+a30,30 0 1,0  60,0
+
+M50,40 m2.5,-2.5
+l17.5,17.5
+a 2.5,2.5 0 0 1 -5,5
+l-15,-15
+l-15,15
+a 2.5,2.5 0 0 1 -5,-5
+l17.5,-17.5
+a 3.5,3.5 0 0 1 5,0`;
+
+export interface LinkArrowIconProps {
+  color?: string;
+  size: number;
+}
+
+export function LinkArrowIcon({ color, size }: LinkArrowIconProps) {
+  return (
+    <svg viewBox="0 0 100 100" fill={color} width={size} height={size}>
+      <path d={arrowIconPath} />
+    </svg>
+  );
+}
+
+export function LinkArrowIconHTML(props: LinkArrowIconProps) {
+  // Renders the component to HTML without using renderToString (which would greatly increase bundle sizes).
+  // https://react.dev/reference/react-dom/server/renderToString#removing-rendertostring-from-the-client-code
+
+  const div = document.createElement("div");
+  const root = createRoot(div);
+  flushSync(() => {
+    root.render(<LinkArrowIcon {...props} />);
+  });
+  return div.innerHTML;
+}

--- a/src/PhotosphereEditor.tsx
+++ b/src/PhotosphereEditor.tsx
@@ -11,6 +11,7 @@ import {
   Photosphere,
   VFE,
   newID,
+  photosphereLinkTooltip,
 } from "./DataStructures.ts";
 import { deleteStoredVFE, save } from "./FileOperations.ts";
 import { VisitedState } from "./HandleVisit.tsx";
@@ -382,6 +383,7 @@ function PhotosphereEditor({
         if (newPhotosphereID !== null) {
           hotspots[id] = {
             ...hotspot,
+            tooltip: photosphereLinkTooltip(newPhotosphereID),
             data: { tag: "PhotosphereLink", photosphereID: newPhotosphereID },
           };
         }

--- a/src/PhotosphereViewer.tsx
+++ b/src/PhotosphereViewer.tsx
@@ -96,11 +96,14 @@ function sizeToStr(val: number): string {
 }
 
 /** Convert non-link hotspots to markers with type-based content/icons */
-function convertHotspots(hotspots: Record<string, Hotspot3D>): MarkerConfig[] {
+function convertHotspots(
+  hotspots: Record<string, Hotspot3D>,
+  isViewerMode: boolean,
+): MarkerConfig[] {
   const markers: MarkerConfig[] = [];
 
   for (const hotspot of Object.values(hotspots)) {
-    if (hotspot.data.tag === "PhotosphereLink") continue;
+    if (isViewerMode && hotspot.data.tag === "PhotosphereLink") continue;
 
     markers.push({
       id: hotspot.id,
@@ -122,7 +125,14 @@ interface LinkData {
 }
 
 /** Convert photosphere-link hotspots to virtual tour links  */
-function convertLinks(hotspots: Record<string, Hotspot3D>): VirtualTourLink[] {
+function convertLinks(
+  hotspots: Record<string, Hotspot3D>,
+  isViewerMode: boolean,
+): VirtualTourLink[] {
+  if (!isViewerMode) {
+    return [];
+  }
+
   const links: VirtualTourLink[] = [];
 
   for (const hotspot of Object.values(hotspots)) {
@@ -215,6 +225,8 @@ function PhotosphereViewer({
   const [visited, handleVisit] = useVisitedState(initialPhotosphereHotspots);
   console.log("in viewer", visited);
 
+  const isViewerMode = onUpdateHotspot === undefined;
+
   useEffect(() => {
     if (ready.current) {
       const virtualTour =
@@ -286,8 +298,8 @@ function PhotosphereViewer({
           id: p.id,
           panorama: p.src.path,
           name: p.id,
-          markers: convertHotspots(p.hotspots),
-          links: convertLinks(p.hotspots),
+          markers: convertHotspots(p.hotspots, isViewerMode),
+          links: convertLinks(p.hotspots, isViewerMode),
         };
       },
     );

--- a/src/PhotosphereViewer.tsx
+++ b/src/PhotosphereViewer.tsx
@@ -401,6 +401,10 @@ function PhotosphereViewer({
             setHotspotArray([]);
           }}
           onUpdateHotspot={onUpdateHotspot}
+          changeScene={(id) => {
+            setCurrentPhotosphere(vfe.photospheres[id]);
+            onChangePS(id);
+          }}
         />
       )}
 

--- a/src/PhotosphereViewer.tsx
+++ b/src/PhotosphereViewer.tsx
@@ -156,7 +156,7 @@ function convertLinks(
         pitch: degToStr(hotspot.pitch),
         yaw: degToStr(hotspot.yaw),
       },
-      data: { tooltip: "Go " + hotspot.data.photosphereID } as LinkData,
+      data: { tooltip: hotspot.tooltip } as LinkData,
     });
   }
 

--- a/src/PhotosphereViewer.tsx
+++ b/src/PhotosphereViewer.tsx
@@ -21,8 +21,10 @@ import {
   Stack,
   Switch,
   SwitchProps,
+  alpha,
   styled,
 } from "@mui/material";
+import { common } from "@mui/material/colors";
 
 import AudioToggleButton from "./AudioToggleButton";
 import {
@@ -33,6 +35,7 @@ import {
   VFE,
 } from "./DataStructures";
 import { useVisitedState } from "./HandleVisit";
+import { LinkArrowIconHTML } from "./LinkArrowIcon";
 import PhotosphereSelector from "./PhotosphereSelector";
 import PopOver from "./PopOver";
 import { HotspotUpdate } from "./VFEConversion";
@@ -105,16 +108,25 @@ function convertHotspots(
   for (const hotspot of Object.values(hotspots)) {
     if (isViewerMode && hotspot.data.tag === "PhotosphereLink") continue;
 
-    markers.push({
+    const marker: MarkerConfig = {
       id: hotspot.id,
-      image: hotspot.icon.path,
       size: { width: 64, height: 64 },
       position: {
         yaw: degToStr(hotspot.yaw),
         pitch: degToStr(hotspot.pitch),
       },
       tooltip: hotspot.tooltip,
-    });
+    };
+    if (hotspot.data.tag === "PhotosphereLink") {
+      marker.html = LinkArrowIconHTML({
+        color: alpha(common.white, 0.8),
+        size: 80,
+      });
+    } else {
+      marker.image = hotspot.icon.path;
+    }
+
+    markers.push(marker);
   }
 
   return markers;

--- a/src/PopOver.tsx
+++ b/src/PopOver.tsx
@@ -26,11 +26,18 @@ import { confirmMUI } from "./StyledDialogWrapper";
 import { HotspotUpdate } from "./VFEConversion";
 
 interface HotspotContentProps {
+  tooltip: string;
   hotspot: HotspotData;
   openNestedHotspot: (add: Hotspot2D) => void;
+  changeScene: (id: string) => void;
 }
 
-function HotspotContent({ hotspot, openNestedHotspot }: HotspotContentProps) {
+function HotspotContent({
+  tooltip,
+  hotspot,
+  openNestedHotspot,
+  changeScene,
+}: HotspotContentProps) {
   const [answer, setAnswer] = useState(""); // State to hold the answer
   const [feedback, setFeedback] = useState("");
 
@@ -121,7 +128,24 @@ function HotspotContent({ hotspot, openNestedHotspot }: HotspotContentProps) {
         </Box>
       );
     case "PhotosphereLink":
-      break;
+      return (
+        <Stack
+          width="20vw"
+          height="100%"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <Button
+            size="large"
+            variant="contained"
+            onClick={() => {
+              changeScene(hotspot.photosphereID);
+            }}
+          >
+            {tooltip}
+          </Button>
+        </Stack>
+      );
     case "Quiz": {
       const hotspotAnswer = hotspot.answer;
       return (
@@ -159,8 +183,6 @@ function HotspotContent({ hotspot, openNestedHotspot }: HotspotContentProps) {
         </Box>
       );
     }
-    default:
-      break;
   }
 }
 
@@ -174,6 +196,7 @@ export interface PopOverProps {
     hotspotPath: string[],
     update: HotspotUpdate | null,
   ) => void;
+  changeScene: (id: string) => void;
 }
 
 function PopOver(props: PopOverProps) {
@@ -310,8 +333,10 @@ function PopOver(props: PopOverProps) {
           {previewData && (
             <DialogContent sx={{ paddingTop: 0 }}>
               <HotspotContent
+                tooltip={previewTooltip}
                 hotspot={previewData}
                 openNestedHotspot={openNestedHotspot}
+                changeScene={props.changeScene}
               />
             </DialogContent>
           )}

--- a/src/VFELoader.tsx
+++ b/src/VFELoader.tsx
@@ -63,6 +63,16 @@ function VFELoader({ render }: PhotosphereLoaderProps) {
     );
   }
 
+  if (photosphereID && !(photosphereID in vfe.photospheres)) {
+    return (
+      <Stack minHeight="100vh" alignItems="center" justifyContent="center">
+        <Alert variant="filled" severity="error">
+          Photosphere &apos;{photosphereID}&apos; not found.
+        </Alert>
+      </Stack>
+    );
+  }
+
   return render({
     vfe,
     onUpdateVFE: (updatedVFE) => {

--- a/src/buttons/AddHotspot.tsx
+++ b/src/buttons/AddHotspot.tsx
@@ -19,6 +19,7 @@ import {
   HotspotData,
   calculateImageDimensions,
   newID,
+  photosphereLinkTooltip,
 } from "../DataStructures.ts";
 import { alertMUI } from "../StyledDialogWrapper.tsx";
 
@@ -438,8 +439,8 @@ function AddHotspot({ onAddHotspot, onCancel, pitch, yaw }: AddHotspotProps) {
 
   async function handleAddHotspot() {
     if (
-      tooltip.trim() === "" ||
       hotspotData === null ||
+      (hotspotData.tag !== "PhotosphereLink" && tooltip.trim() === "") ||
       (hotspotData.tag !== "PhotosphereLink" && iconAsset === null)
     ) {
       await alertMUI(
@@ -448,12 +449,17 @@ function AddHotspot({ onAddHotspot, onCancel, pitch, yaw }: AddHotspotProps) {
       return;
     }
 
+    let generatedTooltip = tooltip;
+    if (hotspotData.tag === "PhotosphereLink") {
+      generatedTooltip = photosphereLinkTooltip(hotspotData.photosphereID);
+    }
+
     const newHotspot: Hotspot3D = {
       id: newID(),
-      tooltip: tooltip,
-      pitch: pitch,
-      yaw: yaw,
-      level: level,
+      tooltip: generatedTooltip,
+      pitch,
+      yaw,
+      level,
       icon: iconAsset ?? defaultIcon(), // store default icon for photosphere links
       data: hotspotData,
     };
@@ -501,13 +507,16 @@ function AddHotspot({ onAddHotspot, onCancel, pitch, yaw }: AddHotspotProps) {
           sx={{ flexGrow: 1 }}
         />
       </Stack>
-      <TextField
-        required
-        label="Tooltip"
-        onChange={(e) => {
-          setTooltip(e.target.value);
-        }}
-      />
+
+      {hotspotData?.tag !== "PhotosphereLink" && (
+        <TextField
+          required
+          label="Tooltip"
+          onChange={(e) => {
+            setTooltip(e.target.value);
+          }}
+        />
+      )}
 
       <HotspotDataEditor
         hotspotData={hotspotData}


### PR DESCRIPTION
Closes #88 

* In editor mode, turns photosphere links into normal hotspots with a custom SVG icon that replicates the viewer link icon.
* Disables icon and tooltip fields for photosphere link hotspots.
* Generated tooltips for photosphere links are now stored instead of being created on the fly.
* The hotspot content for photosphere links is now a button to that photosphere. This content is only visible as a nested hotspot or in the editor mode: ![image](https://github.com/kingsawpdx/virtualFieldEnvironments/assets/25037249/7230b7c6-48c0-4086-afc2-fe0e27550336)
