### PR TITLE
Improve photosphere selector in editor

### DIFF
--- a/src/PhotosphereSelector.tsx
+++ b/src/PhotosphereSelector.tsx
@@ -1,51 +1,55 @@
-import {
-  FormControl,
-  InputLabel,
-  MenuItem,
-  Select,
-  Stack,
-} from "@mui/material";
+import { FormControl, InputLabel, MenuItem, Select } from "@mui/material";
 
 export interface PhotosphereSelectorProps {
   options: string[];
   value: string;
   setValue: (value: string) => void;
+  size?: "medium" | "small";
 }
 
-function PhotosphereSelector(props: PhotosphereSelectorProps) {
+function PhotosphereSelector({
+  options,
+  value,
+  setValue,
+  size = "medium",
+}: PhotosphereSelectorProps) {
+  // Helper function to reduce ternary/undefined repetition.
+  function ifSmall<T, D>(value: T, defaultValue?: D): T | D | undefined {
+    return size === "small" ? value : defaultValue;
+  }
+
   return (
-    <Stack
-      sx={{
-        width: "150px",
-        padding: "0 5px",
-        justifyContent: "space-around",
-      }}
-    >
-      <FormControl size="small">
-        <InputLabel id="scene-select" sx={{ fontSize: "14px" }}>
-          Scene
-        </InputLabel>
-        <Select
-          labelId="scene-select"
-          label="Scene"
-          value={props.value}
-          onChange={(e) => {
-            props.setValue(e.target.value);
-          }}
-          sx={{
+    <FormControl size={size}>
+      <InputLabel id="scene-select" sx={ifSmall({ fontSize: "14px" })}>
+        Scene
+      </InputLabel>
+      <Select
+        labelId="scene-select"
+        label="Scene"
+        value={value}
+        onChange={(e) => {
+          setValue(e.target.value);
+        }}
+        sx={ifSmall(
+          {
             fontSize: "14px",
             width: "150px",
             height: "35px",
-          }}
-        >
-          {props.options.map((option) => (
-            <MenuItem key={option} value={option} sx={{ fontSize: "13px" }}>
-              {option}
-            </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
-    </Stack>
+          },
+          { minWidth: "150px" },
+        )}
+      >
+        {options.map((option) => (
+          <MenuItem
+            key={option}
+            value={option}
+            sx={ifSmall({ fontSize: "13px" })}
+          >
+            {option}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
   );
 }
 

--- a/src/PhotosphereViewer.tsx
+++ b/src/PhotosphereViewer.tsx
@@ -17,6 +17,7 @@ import {
 } from "react-photo-sphere-viewer";
 
 import {
+  Box,
   FormControlLabel,
   Stack,
   Switch,
@@ -355,17 +356,21 @@ function PhotosphereViewer({
           boxShadow: "0 0 4px grey",
           zIndex: 100,
           justifyContent: "space-between",
+          alignItems: "center",
         }}
         gap={1}
       >
-        <PhotosphereSelector
-          options={Object.keys(vfe.photospheres)}
-          value={currentPhotosphere.id}
-          setValue={(id) => {
-            setCurrentPhotosphere(vfe.photospheres[id]);
-            onChangePS(id);
-          }}
-        />
+        <Box sx={{ padding: "0 5px" }}>
+          <PhotosphereSelector
+            size="small"
+            options={Object.keys(vfe.photospheres)}
+            value={currentPhotosphere.id}
+            setValue={(id) => {
+              setCurrentPhotosphere(vfe.photospheres[id]);
+              onChangePS(id);
+            }}
+          />
+        </Box>
         {currentPhotosphere.backgroundAudio && (
           <AudioToggleButton src={currentPhotosphere.backgroundAudio.path} />
         )}

--- a/src/PopOver.tsx
+++ b/src/PopOver.tsx
@@ -228,6 +228,11 @@ function PopOver({
       ? setPreviewIcon
       : undefined;
 
+  const availablePhotosphereOptions =
+    hotspot.data.tag === "PhotosphereLink"
+      ? [hotspot.data.photosphereID, ...photosphereOptions]
+      : photosphereOptions;
+
   async function keepChanges() {
     const confirmed = await confirmMUI(
       "All changes to the current hotspot will be lost. Continue?",
@@ -374,7 +379,7 @@ function PopOver({
                 deleteHotspot={deleteHotspot}
                 updateHotspot={updateHotspot}
                 openNestedHotspot={openNestedHotspot}
-                photosphereOptions={photosphereOptions} // Pass down the new props
+                photosphereOptions={availablePhotosphereOptions} // Pass down the new props
               />
             </Box>
           )}

--- a/src/buttons/EditNavMap.tsx
+++ b/src/buttons/EditNavMap.tsx
@@ -31,7 +31,8 @@ function EditNavMap({ onClose, vfe, onUpdateVFE }: EditNavMapProps) {
   const options: string[] = Object.keys(vfe.photospheres);
 
   const selectorProps: PhotosphereSelectorProps = {
-    options: options,
+    size: "small",
+    options,
     value: selectedPhotosphere,
     setValue: setSelectedPhotosphere,
   };


### PR DESCRIPTION
Two small changes to the photosphere selector to make it nicer in the editor:
1. Add the current photosphere ID to the list of options. Previously, it wouldn't be possible to select the current option when editing a photosphere link hotspot.
2. Allow photosphere selector to be full size. Previously, it would always be small, which made it look out of place next to the other edit hotspot fields.


| Before | After |
| - | - |
| ![image](https://github.com/kingsawpdx/virtualFieldEnvironments/assets/25037249/7c985c32-3770-46c2-8f1d-4664f2e40cec) | ![image](https://github.com/kingsawpdx/virtualFieldEnvironments/assets/25037249/611a0065-81f2-4ef4-910c-1561287637f0) |